### PR TITLE
Add a shariff-backend-java

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,5 +95,6 @@ In order to display share counts with Shariff, you need one of the following bac
 * [shariff-backend-node](http://github.com/heiseonline/shariff-backend-node)
 * [shariff-backend-perl](http://github.com/heiseonline/shariff-backend-perl)
 * [shariff-backend-php](http://github.com/heiseonline/shariff-backend-php)
+* [shariff-backend-java](http://github.com/headissue/shariff-backend-java)
 
 Once you have one of these backends up and running, insert its URL into the `data-backend-url` attribute. For example, if the backend runs under `http://example.com/my-shariff-backend/`, the `data-backend-url` should be `/my-shariff-backend/`. The script will handle the rest. 


### PR DESCRIPTION
Hey guys

we coincidentally worked on a sharecount clone in java which equals the API of your other backends. It would be nice if you could look into our project and add it to your list of backends.

Regards
Wormi
