### PR TITLE
[BUGFIX] Make shariff.js work with IE

### DIFF
--- a/build/shariff.js
+++ b/build/shariff.js
@@ -10592,7 +10592,7 @@ _Shariff.prototype = {
             e.preventDefault();
 
             var url = $(this).attr('href');
-            var windowName = $(this).attr('title');
+            var windowName = "_blank";
             var windowSizeX = '600';
             var windowSizeY = '460';
             var windowSize = 'width=' + windowSizeX + ',height=' + windowSizeY;


### PR DESCRIPTION
Since IE does not allow spaces in the window name we use „_blank“ as
window name.

See:
http://stackoverflow.com/questions/710756/ie8-var-w-window-open-message-
invalid-argument/1462500#1462500