### PR TITLE
Twitter: prevent double encoding with text longer than 120 chars

### DIFF
--- a/src/js/services/twitter.js
+++ b/src/js/services/twitter.js
@@ -11,7 +11,7 @@ var abbreviateText = function(text, length) {
     }
 
     var lastWhitespaceIndex = abbreviated.substring(0, length - 1).lastIndexOf(' ');
-    abbreviated = encodeURIComponent(abbreviated.substring(0, lastWhitespaceIndex)) + '\u2026';
+    abbreviated = abbreviated.substring(0, lastWhitespaceIndex) + '\u2026';
 
     return abbreviated;
 };


### PR DESCRIPTION
URL-String is uri-encoded by url.format (by means of querystring.stringify).