### PR TITLE
Add WordPress plugin to third party list

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -122,3 +122,4 @@ Bekannte Shariff-Integrationen für Drittanbieter-Systeme:
 * [Joomla 3.4+ Shariff Plugin](https://github.com/joomla-agency/plg_jooag_shariff)
 * [TYPO3-Plugin rx_shariff](http://typo3.org/extensions/repository/view/rx_shariff)
 * [Wordpress-Plugin shariff-sharing](https://wordpress.org/plugins/shariff-sharing/)
+* [WordPress-Plugin Shariff Wrapper](https://wordpress.org/plugins/shariff/)

--- a/README.md
+++ b/README.md
@@ -122,3 +122,4 @@ This is a list of integrations for third-party systems:
 * [Joomla 3.4+ Shariff Plugin](https://github.com/joomla-agency/plg_jooag_shariff)
 * [TYPO3 Plugin rx_shariff](http://typo3.org/extensions/repository/view/rx_shariff)
 * [Wordpress Plugin shariff-sharing](https://wordpress.org/plugins/shariff-sharing/)
+* [WordPress Plugin Shariff Wrapper](https://wordpress.org/plugins/shariff/)


### PR DESCRIPTION
Adds the WordPress plugin "Shariff Wrapper" to the list of third party
integrations. It is up to date with Shariff version 1.14.0 and the PHP
backend version 1.5.