### PR TITLE
add attributes for screen readers

### DIFF
--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -211,6 +211,10 @@ Shariff.prototype = {
             }
             $shareLink.attr('title', self.getLocalized(service, 'title'));
 
+            // add attributes for screen readers
+            $shareLink.attr('role', 'button');
+            $shareLink.attr('aria-label', self.getLocalized(service, 'title'));
+
             $li.append($shareLink);
 
             $buttonList.append($li);


### PR DESCRIPTION
Fügt den Button-Links die Attribute role=“button“ und aria-label=“title-attribut-des-jeweiligen-dienstes“ hinzu. Dadurch lesen Screen Reader nicht mehr „teilen“ bei fast jedem Button vor, sondern das ausführlichere „Bei Facebook teilen“, „Bei XING teilen“, etc. - natürlich in der jeweiligen Sprache. Auf diese Weise kann beim Einsatz von Screen Readern besser, bzw. überhaupt, zwischen den Buttons unterschieden werden.