### PR TITLE
fix-pinterest-link

### DIFF
--- a/src/js/services/pinterest.js
+++ b/src/js/services/pinterest.js
@@ -9,7 +9,7 @@ module.exports = function(shariff) {
         title += ' - ' + creator;
     }
 
-    var shareUrl = url.parse('https://www.pinterest.com/pin/create/button/', true);
+    var shareUrl = url.parse('https://www.pinterest.com/pin/create/link/', true);
     shareUrl.query.url = shariff.getURL();
     shareUrl.query.media = shariff.getOption('mediaUrl');
     shareUrl.query.description = title;


### PR DESCRIPTION
Changes the Pinterest share link from „button“ to „link“ so the Shariff
Button is not replaced with the original button in case the pinit.js is
present.

Fix for https://github.com/heiseonline/shariff/issues/86