### PR TITLE
modified package.json for grunt demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "browserify-shim": "^3.8.3",
     "grunt": "^0.4.5",
     "grunt-browserify": "^3.7.0",
-    "grunt-connect-proxy": "^0.1.10",
+    "grunt-connect-proxy": "^0.2.0",
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-jshint": "^0.11.1",


### PR DESCRIPTION
Grunt demo does not start:

$ grunt demo
Loading "connect_proxy.js" tasks...ERROR
>> TypeError: Cannot read property 'prototype' of undefined
Warning: Task "configureProxies:demo" not found. Use --force to continue.

Aborted due to warnings.

The modification of the file "package.json" ("grunt-connect-proxy": "^0.2.0") fixes the problem.