### PR TITLE
get Pinterest Media by Open Graph Tag

### DIFF
--- a/src/js/services/pinterest.js
+++ b/src/js/services/pinterest.js
@@ -8,10 +8,14 @@ module.exports = function(shariff) {
     if (creator.length > 0) {
         title += ' - ' + creator;
     }
+    var img = shariff.getOption('mediaUrl');
+    if (img.length <= 0) {
+        img = shariff.getMeta('og:image');
+    }
 
     var shareUrl = url.parse('https://www.pinterest.com/pin/create/link/', true);
     shareUrl.query.url = shariff.getURL();
-    shareUrl.query.media = shariff.getOption('mediaUrl');
+    shareUrl.query.media = img;
     shareUrl.query.description = title;
     delete shareUrl.search;
 


### PR DESCRIPTION
With this little change the image for pinterest will be get from the Open Graph Tag if no data-media-URL is set.