### PR TITLE
optimized styles for new fa-google-plus icon

### DIFF
--- a/src/style/services/googleplus.less
+++ b/src/style/services/googleplus.less
@@ -25,8 +25,6 @@
     .shariff {
         .googleplus .fa-google-plus {
             font-size: 19px;
-            position: relative;
-            top: 1px;
         }
     }
 }


### PR DESCRIPTION
fontawesome updated the google-plus icon and now it's squared and the offset from top should be removed