### PR TITLE
Changed the diaspora url to the official share url

### DIFF
--- a/src/js/services/diaspora.js
+++ b/src/js/services/diaspora.js
@@ -3,7 +3,7 @@
 var url = require('url');
 
 module.exports = function(shariff) {
-    var shareUrl = url.parse('https://sharetodiaspora.github.io/', true);
+    var shareUrl = url.parse('https://share.diasporafoundation.org/', true);
     shareUrl.query.url = shariff.getURL();
     shareUrl.query.title = shariff.getTitle() || shariff.getMeta('DC.title');
     shareUrl.protocol = 'https';


### PR DESCRIPTION
There is an official instance of the share widget that should be used instead.
It is used by the Firefox Share Service ( https://activations.cdn.mozilla.net/de/diaspora.html ) and is hosted on resources belonging to the project itself (more trustworthy / reliable).