### PR TITLE
Allow any 2.x.x jQuery version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,6 +32,6 @@
     "tests"
   ],
   "dependencies": {
-    "jquery": "~2.1.1"
+    "jquery": "^2.1.1"
   }
 }


### PR DESCRIPTION
I'm pretty sure this won't break anything and it will prevent quite a few package conflicts.
Also I noticed that jQuery version `^1.11.2` is registered inside the `package.json`, for me this difference makes no seance at all.
