### PR TITLE
Add {url} replacement to mailBody

### DIFF
--- a/src/js/services/mail.js
+++ b/src/js/services/mail.js
@@ -6,7 +6,7 @@ module.exports = function(shariff) {
     // mailto: link? Add body and subject.
     if (url.indexOf('mailto:') === 0) {
         url += '?subject=' + encodeURIComponent(shariff.getOption('mailSubject'));
-        url += '&body=' + encodeURIComponent(shariff.getOption('mailBody'));
+        url += '&body=' + encodeURIComponent(shariff.getOption('mailBody').replace(/\{url\}/i, shariff.getURL()));
     }
 
     return {


### PR DESCRIPTION
I am using the TYPO3-extension `rx_shariff` and if i set the attribute `data-mail-body`, it completely replaces the URL which will be inserted automatically if there is no `data-mail-body`-attribute.

But a mail without link does not make any sense, so i would like to replace the placeholder `{url}` with `shariff.getURL()`.

Is this the right place for such modification?
