### PR TITLE
Fix: Twitter popup opens twice when a tweet is embedded on a page.

### DIFF
--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -239,6 +239,16 @@ Shariff.prototype = {
             e.preventDefault();
 
             var url = $(this).attr('href');
+
+            // if a twitter widget is embedded on current site twitter's widget.js
+            // will open a popup so we should not open a second one.
+            if (url.match(/twitter\.com\/intent\/(\w+)/)) {
+                var w = global.window;
+                if(w.__twttr && w.__twttr.widgets && w.__twttr.widgets.loaded) {
+                    return;
+                }
+            }
+
             var windowName = '_blank';
             var windowSizeX = '600';
             var windowSizeY = '460';


### PR DESCRIPTION
When a Tweet is embedded in a page (example below) and shariff is implemented on the same page the script `platform.twitter.com/widgets.js` auomatically opens a second sharing popup when the tweet link is clicked.

This PR checks for the precence of twitters widgets.js and prevents the opening of a second popup.

Example for embedded tweet:

```HTML
<blockquote class="twitter-tweet" data-lang="de"><p lang="en" dir="ltr">Shariff Social Media Buttons (8.x-1.1) released <a href="https://t.co/vaesZ6z0fK">https://t.co/vaesZ6z0fK</a> ! <a href="https://twitter.com/hashtag/shariff?src=hash">#shariff</a> <a href="https://twitter.com/hashtag/d8module?src=hash">#d8module</a> <a href="https://twitter.com/hashtag/d8stable?src=hash">#d8stable</a> <a href="https://twitter.com/hashtag/Drupal8?src=hash">#Drupal8</a></p>&mdash; Drupal8Contrib (@drupal8contrib) <a href="https://twitter.com/drupal8contrib/status/818950486439186433">10. Januar 2017</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
```