### PR TITLE
replace jquery with vanilla js, save 240% file size

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -8,7 +8,7 @@
     // Predefined globals
 
     // Whether the standard browser globals should be predefined.
-    "browser": false,
+    "browser": true,
     // Whether the Node.js environment globals should be predefined.
     "node": true,
     // Whether the Rhino environment globals should be predefined.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master
+
+* Replaced jQuery with vanilla js (glaszig)
+
 ## 1.24.1 2016-11-17
 
 * Fixed mail body handling on some mobile devices.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,18 +38,10 @@ module.exports = function(grunt) {
                 src: 'src/js/shariff.js',
                 dest: 'demo/app.min.js'
             },
-            dist_complete_min: {
-                options: {
-                    transform: [ ['uglifyify', { global: true } ] ]
-                },
-                src: 'src/js/shariff.js',
-                dest: 'build/shariff.complete.js'
-            },
             dist_min: {
                 options: {
                     transform: [
-                        ['uglifyify', { global: true } ],
-                        ['browserify-shim', { global: true } ]
+                        ['uglifyify', { global: true } ]
                     ]
                 },
                 src: 'src/js/shariff.js',
@@ -193,7 +185,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-hapi');
 
     grunt.registerTask('test', ['jshint']);
-    grunt.registerTask('build', ['test', 'less:demo', 'less:dist', 'less:dist_min', 'browserify:dist_complete_min', 'browserify:dist_min']);
+    grunt.registerTask('build', ['test', 'less:demo', 'less:dist', 'less:dist_min', 'browserify:dist_min']);
     grunt.registerTask('demo', ['copy:demo', 'less:demo', 'browserify:demo', 'hapi', 'configureProxies:demo', 'connect']);
     grunt.registerTask('default', ['test', 'demo']);
 };

--- a/README-de.md
+++ b/README-de.md
@@ -17,8 +17,7 @@ Shariff besteht aus zwei Teilen. Der erste Teil ist eine einfache JavaScript-Bib
     * `build/shariff.complete.css` enthält alle Abhängigkeiten
     * `build/shariff.min.css` verwenden, wenn [Font Awesome](https://github.com/FortAwesome/Font-Awesome) bereits in Ihrer Seite geladen wird
 3. JavaScript unmittelbar vor `</body>` einbinden:
-    * `build/shariff.complete.js` enthält alle Abhängigkeiten
-    * `build/shariff.min.js` verwenden, wenn [jQuery](https://github.com/jquery/jquery) bereits in der Seite vorhanden ist
+    * `build/shariff.min.js`
 4. Beliebig viele `<div class="shariff">` Elemente einfügen
 5. Mit den unten beschriebenen `data`-Attributen Aussehen und Funktion konfigurieren
 
@@ -43,7 +42,7 @@ Code-Beispiel:
     <div class="shariff" data-backend-url="/path/to/backend" data-url="http://www.example.com/my-article.html" data-theme="grey" data-orientation="vertical"></div>
 
     <!-- vor dem schließenden </body>-Tag -->
-    <script src="/path/to/shariff.complete.js"></script>
+    <script src="/path/to/shariff.min.js"></script>
 </body>
 </html>
 ```
@@ -62,8 +61,7 @@ Dann kann Shariff im eigenen Skript initialisiert und an DOM-Elemente gebunden w
 ```js
 // my-app.js
 var Shariff = require('shariff');
-var $ = require('jquery');
-var buttonsContainer = $('.some-selector');
+var buttonsContainer = document.querySelector('.some-selector');
 new Shariff(buttonsContainer, {
     orientation: 'vertical'
 });

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ Shariff consists of two parts: a simple JavaScript client library and an optiona
     * `build/shariff.complete.css` contains all dependencies
     * if [Font Awesome](https://github.com/FortAwesome/Font-Awesome) is already included in your site, use `build/shariff.min.css` 
 3. Include JavaScript right before `</body>`:
-    * `build/shariff.complete.js` contains all dependencies
-    * if [jQuery](https://github.com/jquery/jquery) is already included in your site, use `build/shariff.min.js`
+    * `build/shariff.min.js`
 4. Insert one or more `<div class="shariff">` elements.
 5. Customize the look using data-* attributes.
 
@@ -62,8 +61,7 @@ Edit your JS main script, include Shariff and initialize it in one or more conta
 ```js
 // my-app.js
 var Shariff = require('shariff');
-var $ = require('jquery');
-var buttonsContainer = $('.some-selector');
+var buttonsContainer = document.querySelector('.some-selector');
 new Shariff(buttonsContainer, {
     orientation: 'vertical'
 });

--- a/bower.json
+++ b/bower.json
@@ -30,8 +30,5 @@
     "bower_components",
     "test",
     "tests"
-  ],
-  "dependencies": {
-    "jquery": "^2.1.1"
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -33,12 +33,8 @@
       "email": "dzs@heise.de"
     }
   ],
-  "browserify-shim": {
-    "jquery": "global:jQuery"
-  },
   "dependencies": {
-    "font-awesome": "^4.3.0",
-    "jquery": "^1.11.2"
+    "font-awesome": "^4.3.0"
   },
   "publishConfig": {
     "registry": "http://registry.npmjs.org"

--- a/src/js/dom.js
+++ b/src/js/dom.js
@@ -1,0 +1,446 @@
+'use strict';
+
+/**
+ * Initialization helper. This method is this module's exported entry point.
+ * @param {string|Array|Element} selector - css selector, one element, array of nodes or html fragment
+ * @param {node} [context=document] - context node in which to query
+ * @returns {DOMQuery} A DOMQuery instance containing the selected set of nodes
+ */
+function dq(selector, context) {
+  var nodes = [];
+  context = context || document;
+  if (selector instanceof Element) {
+    nodes = [ selector ];
+  } else if (typeof selector === 'string') {
+    if (selector[0] === '<') {
+      nodes = fragment(selector);
+    } else {
+      nodes = Array.prototype.slice.call(context.querySelectorAll(selector));
+    }
+  } else {
+    nodes = selector;
+  }
+  return new DOMQuery(nodes, context);
+}
+
+/**
+ * Contains a set of DOM nodes and provides methods to manipulate the nodes.
+ * @constructor
+ */
+function DOMQuery(elements, context) {
+  this.length = elements.length;
+  this.context = context;
+  var self = this;
+  each(elements, function(i) { self[i] = this; });
+}
+
+/**
+ * Iterates through each node and calls the callback in its context.
+ * @param {eachArrayCallback} callback - A function to be called with a node
+ * @returns {DOMQuery}
+ */
+DOMQuery.prototype.each = function(callback) {
+  for (var i = this.length - 1; i >= 0; i--) {
+    callback.call(this[i], i, this[i]);
+  }
+  return this;
+};
+
+/**
+ * Empties each node.
+ * @returns {DOMQuery}
+ */
+DOMQuery.prototype.empty = function() {
+  return this.each(empty);
+};
+
+/**
+ * Sets the text content of each node. Returns the text content of the first node.
+ * @param {string} [text] - The text content to set
+ * @returns {DOMQuery|string}
+ */
+DOMQuery.prototype.text = function(text) {
+  if (text === undefined) {
+    return this[0].textContent;
+  }
+  return this.each(function () { this.textContent = text; });
+};
+
+/**
+ * Sets an attribute on each node. Returns the attribute's value of the first node.
+ * @param {string} [name] - The attribute's name
+ * @param {string} [value] - The value to set
+ * @returns {DOMQuery|string}
+ */
+DOMQuery.prototype.attr = function (name, value) {
+  if (this.length < 1) {
+    return null;
+  }
+  if (value === undefined) {
+    return this[0].getAttribute(name);
+  }
+  return this.each(function() { this.setAttribute(name, value); });
+};
+
+/**
+ * Sets a data attribute on each node. Returns the data attribute's value of the first node.
+ * Supports deserialization of complex data types as values.
+ * @param {string} [key] - The attribute's name
+ * @param {string} [value] - The value to set
+ * @returns {DOMQuery|string|Object}
+ */
+DOMQuery.prototype.data = function(key, value) {
+  if (value) {
+    return this.attr('data-' + key, value);
+  }
+  if (key) {
+    return this.attr('data-' + key);
+  }
+  var data = Object.assign({}, this[0].dataset);
+  each(data, function(k, v) { data[k] = deserializeValue(v); });
+  return data;
+};
+
+/**
+ * Returns a new DOMQuery instance containing all matched nodes in the context
+ * of the set of nodes.
+ * @param {string} selector - The CSS selector
+ * @returns {DOMQuery}
+ */
+DOMQuery.prototype.find = function(selector) {
+  var matches;
+  // querySelectorAll in the context of each element in the set
+  matches = map(this, function(el) { return el.querySelectorAll(selector); });
+  // convert NodeList matches into Array
+  matches = map(matches, function(el) { return Array.prototype.slice.call(el); });
+  // flatten the array
+  matches = Array.prototype.concat.apply([], matches);
+  return new DOMQuery(matches);
+};
+
+/**
+ * Appends nodes to the end of the first node in the set.
+ * @param {string|Array} html - Nodes to append. May be a string containing HTML.
+ * @returns {DOMQuery}
+ */
+DOMQuery.prototype.append = function(html) {
+  if (typeof html === 'string') {
+    html = fragment(html);
+  }
+  append(this[0], html);
+  return this;
+};
+
+/**
+ * Prepends nodes at the top of the first node in the set.
+ * @param {string|Array} html - Nodes to append. May be a string containing HTML.
+ * @returns {DOMQuery}
+ */
+DOMQuery.prototype.prepend = function(html) {
+  if (typeof html === 'string') {
+    html = fragment(html);
+  }
+  prepend(this[0], html);
+  return this;
+};
+
+/**
+ * Adds a CSS class name to the nodes in the set.
+ * @param {string} name - Class name to add
+ * @returns {DOMQuery}
+ */
+DOMQuery.prototype.addClass = function(name) {
+  return this.each(function() { this.classList.add(name); });
+};
+
+/**
+ * Removes a CSS class name from the nodes in the set.
+ * @param {string} name - Class name to remove
+ * @returns {DOMQuery}
+ */
+DOMQuery.prototype.removeClass = function(name) {
+  return this.each(function() { this.classList.remove(name); });
+};
+
+/**
+ * Delegates an event for a node matching a selector to each element in the set.
+ * @param {string} event - The event name
+ * @param {string} selector - The CSS selector
+ * @param {eventHandler} handler - The event handler function
+ * @returns {DOMQuery}
+ */
+DOMQuery.prototype.on = function(event, selector, handler) {
+  return this.each(function() {
+    delegateEvent(selector, event, handler, this);
+  });
+};
+
+/**
+ * Removes each child of a node.
+ * @private
+ */
+var empty = function () {
+  while (this.hasChildNodes()) {
+    this.removeChild(this.firstChild);
+  }
+};
+
+/**
+ * Callback function used for map(array, callback).
+ *
+ * @callback mapCallback
+ * @param {Object} object - An element of the array
+ * @return {Array}
+ * @see map
+ */
+
+/**
+ * Runs a callback with each element in an array and returns a new array.
+ * @param {Array} objects - The array to iterate
+ * @param {function} callback - The callback function
+ * @returns {Array}
+ */
+var map = function (objects, callback) {
+  return Array.prototype.map.call(objects, callback);
+};
+
+/**
+ * Callback function used for each(array, callback).
+ * Called in the context of each element in the array.
+ *
+ * @callback eachArrayCallback
+ * @param {number} index - Index of the current array element
+ * @param {object} value - Element of the array
+ * @return {Array}
+ * @see each
+ */
+
+/**
+ * Callback function used for each(object, callback).
+ * Called in the context of each object property value.
+ *
+ * @callback eachObjectCallback
+ * @param {Object} key - The object's property key
+ * @param {object} value - The object's property value
+ * @return {Array}
+ * @see each
+ */
+
+/**
+ * Runs a callback with each element in an array or key-value pair of an object.
+ * Returns the original object/array.
+ * @param {Object} object - The object to itrate
+ * @param {eachArrayCallback|eachObjectCallback} callback - The callback function
+ * @returns {Array}
+ */
+var each = function (object, callback) {
+  if (object instanceof Array) {
+    for (var i = 0; i < object.length; i++) {
+      callback.call(object[i], i, object[i]);
+    }
+  } else if (object instanceof Object) {
+    for (var prop in object) {
+      callback.call(object[prop], prop, object[prop], object);
+    }
+  }
+  return object;
+};
+
+/**
+ * Constructs HTML nodes from a string of HTML.
+ * @param {string} html - String of HTML code
+ * @returns {Array}
+ * @private
+ */
+var fragment = function (html) {
+  var div = document.createElement('div');
+  div.innerHTML = html;
+  return div.children;
+};
+
+/**
+ * Appends an array of nodes to the end of an HTML element.
+ * @param {Element} parent - Element to append to
+ * @param {Array} nodes - Collection of nodes to append
+ * @private
+ */
+var append = function (parent, nodes) {
+  for (var i = 0; i < nodes.length; i++) {
+    parent.appendChild(nodes[i]);
+  }
+};
+
+/**
+ * Prepends an array of nodes to the top of an HTML element.
+ * @param {Element} parent - Element to prepend to
+ * @param {Array} nodes - Collection of nodes to prepend
+ * @private
+ */
+var prepend = function (parent, nodes) {
+  for (var i = nodes.length - 1; i >= 0; i--) {
+    parent.insertBefore(nodes[nodes.length-1], parent.firstChild);
+  }
+};
+
+/**
+ * Returns the closest parent of a node matching a CSS selector.
+ * @param {HTMLElement} element - Element to append to
+ * @param {string} selector - CSS selector
+ * @param {HTMLElement}
+ * @private
+ * @see {@link https://gist.github.com/Daniel-Hug/abbded91dd55466e590b}
+ */
+var closest = (function() {
+  var element = HTMLElement.prototype;
+  var matches = element.matches ||
+    element.webkitMatchesSelector ||
+    element.mozMatchesSelector ||
+    element.msMatchesSelector;
+
+  return function closest(element, selector) {
+    return matches.call(element, selector) ?
+      element :
+      closest(element.parentElement, selector);
+  };
+})();
+
+/**
+ * An event handler.
+ *
+ * @callback eventHandler
+ * @param {Event} event - The event this handler was triggered for
+ */
+
+/**
+ * Delegates an event for a node matching a selector.
+ * @param {string} selector - The CSS selector
+ * @param {string} event - The event name
+ * @param {eventHandler} handler - The event handler function
+ * @param {HTMLElement} [scope=document] - Element to add the event listener to
+ * @private
+ */
+var delegateEvent = function (selector, event, handler, scope) {
+  (scope || document).addEventListener(event, function(event) {
+    var listeningTarget = closest(event.target, selector);
+    if (listeningTarget) {
+      handler.call(listeningTarget, event);
+    }
+  });
+};
+
+/**
+ * Extends properties of all arguments into a single object.
+ * @param {...Object} objects - Objects to merge
+ * @param {string} event - The event name
+ * @param {function} handler - The event handler function
+ * @returns {Object}
+ * @see {@link https://gomakethings.com/vanilla-javascript-version-of-jquery-extend/}
+ */
+var extend = function (objects) {
+  // Variables
+  var extended = {};
+  var deep = false;
+  var i = 0;
+  var length = arguments.length;
+
+  // Check if a deep merge
+  if ( Object.prototype.toString.call( arguments[0] ) === '[object Boolean]' ) {
+      deep = arguments[0];
+      i++;
+  }
+
+  // Merge the object into the extended object
+  var merge = function (obj) {
+      for ( var prop in obj ) {
+          if ( Object.prototype.hasOwnProperty.call( obj, prop ) ) {
+              // If deep merge and property is an object, merge properties
+              if ( deep && Object.prototype.toString.call(obj[prop]) === '[object Object]' ) {
+                  extended[prop] = extend( true, extended[prop], obj[prop] );
+              } else {
+                  extended[prop] = obj[prop];
+              }
+          }
+      }
+  };
+
+  // Loop through each object and conduct a merge
+  for ( ; i < length; i++ ) {
+      var obj = arguments[i];
+      merge(obj);
+  }
+
+  return extended;
+};
+
+/**
+ * The callback function for getJSON().
+ *
+ * @callback xhrCallback
+ * @param {boolean} success - True on success. False on error.
+ * @param {Object} data - The parsed data. null if success == false
+ * @param {XMLHttpRequest} xhr - The request object
+ * @see getJSON
+ */
+
+/**
+ * Runs an Ajax request against a url and calls the callback function with
+ * the parsed JSON result.
+ * @param {string} url - The url to request
+ * @param {xhrCallback} callback - The callback function
+ * @returns {XMLHttpRequest}
+ */
+var getJSON = function (url, callback) {
+  var xhr = new XMLHttpRequest();
+  xhr.open('GET', url, true);
+  xhr.setRequestHeader('Content-Type', 'application/json');
+  xhr.setRequestHeader('Accept', 'application/json');
+
+  xhr.onload = function() {
+    if (xhr.status >= 200 && xhr.status < 400) {
+      var data = JSON.parse(xhr.responseText);
+      callback(true, data, xhr);
+    } else {
+      callback(false, null, xhr);
+    }
+  };
+
+  xhr.onerror = function() {
+    callback(false, null, xhr);
+  };
+
+  xhr.send();
+};
+
+/**
+ * Deserializes JSON values from strings. Used with data attributes.
+ * @param {string} value - String to parse
+ * @returns {Object}
+ * @private
+ */
+var deserializeValue = function (value) {
+  /*jshint maxcomplexity:7 */
+  // boolean
+  if ('true' === value) { return true; }
+  if ('false' === value) { return false; }
+  // null
+  if ('null' === value) { return null; }
+  // number
+  if (+value + '' === value) { return +value; }
+  // json
+  if (/^[\[\{]/.test(value)) {
+    try {
+      return JSON.parse(value);
+    } catch(e) {
+      return value;
+    }
+  }
+  // everything else
+  return value;
+};
+
+dq.extend  = extend;
+dq.map     = map;
+dq.each    = each;
+dq.getJSON = getJSON;
+
+module.exports = dq;

--- a/src/js/services/twitter.js
+++ b/src/js/services/twitter.js
@@ -1,11 +1,12 @@
 'use strict';
 
 var url = require('url');
-var $ = require('jquery');
 
 // abbreviate at last blank before length and add "\u2026" (horizontal ellipsis)
 var abbreviateText = function(text, length) {
-    var abbreviated = $('<div/>').html(text).text();
+    var div = document.createElement('div');
+    div.innerHTML = text;
+    var abbreviated = div.textContent;
     if (abbreviated.length <= length) {
         return text;
     }

--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var $ = require('jquery');
+var $ = require('./dom');
 var url = require('url');
 
 var Shariff = function(element, options) {
@@ -53,7 +53,7 @@ var Shariff = function(element, options) {
     this._addButtonList();
 
     if (this.options.backendUrl !== null) {
-        this.getShares().then( $.proxy( this._updateCounts, this ) );
+        this.getShares(this._updateCounts.bind(this));
     }
 
 };
@@ -163,7 +163,7 @@ Shariff.prototype = {
 
     getOption: function(name) {
         var option = this.options[name];
-        return (typeof option === 'function') ? $.proxy(option, this)() : option;
+        return (typeof option === 'function') ? option.call(this) : option;
     },
 
     getTitle: function() {
@@ -175,15 +175,15 @@ Shariff.prototype = {
     },
 
     // returns shareCounts of document
-    getShares: function() {
+    getShares: function(callback) {
         var baseUrl = url.parse(this.options.backendUrl, true);
         baseUrl.query.url = this.getURL();
         delete baseUrl.search;
-        return $.getJSON(url.format(baseUrl));
+        return $.getJSON(url.format(baseUrl), callback);
     },
 
     // add value of shares for each service
-    _updateCounts: function(data) {
+    _updateCounts: function(success, data) {
         var self = this;
         $.each(data, function(key, value) {
             if(value >= 1000) {


### PR DESCRIPTION
motivation: i'd like to use this on a site without jquery and not put the burden of even having to load the bundled jquery bytes just for this little functionallity. we are in 2017, browsers have become good, mobile data volumes (in germany) still suck hard and jquery is overkill for this anyway.

this replaces jquery with a custom (somewhat ugly) shim to save about 240% of file size on non-uglified, uncompressed js.

before: 132945 bytes
after:  38569 bytes

i was not able to integration-test backends, though.