### PR TITLE
resurrect the shariff.complete.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
+## 1.25.2 2017-
+
+* Restored the jQuery dependency for the min.js version. (liayn)
+
 ## 1.25.1 2017-04-21
 
+* RELEASE reverted!
 * Replaced jQuery with vanilla js. (glaszig)
 * Removed obsolete build artifact. 
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,10 +38,18 @@ module.exports = function(grunt) {
                 src: 'src/js/shariff.js',
                 dest: 'demo/app.min.js'
             },
+            dist_complete_min: {
+                options: {
+                    transform: [ ['uglifyify', { global: true } ] ]
+                },
+                src: 'src/js/shariff.js',
+                dest: 'build/shariff.complete.js'
+            },
             dist_min: {
                 options: {
                     transform: [
-                        ['uglifyify', { global: true } ]
+                        ['uglifyify', { global: true } ],
+                        ['browserify-shim', { global: true } ]
                     ]
                 },
                 src: 'src/js/shariff.js',
@@ -185,7 +193,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-hapi');
 
     grunt.registerTask('test', ['jshint']);
-    grunt.registerTask('build', ['test', 'less:demo', 'less:dist', 'less:dist_min', 'browserify:dist_min']);
+    grunt.registerTask('build', ['test', 'less:demo', 'less:dist', 'less:dist_min', 'browserify:dist_complete_min', 'browserify:dist_min']);
     grunt.registerTask('demo', ['copy:demo', 'less:demo', 'browserify:demo', 'hapi', 'configureProxies:demo', 'connect']);
     grunt.registerTask('default', ['test', 'demo']);
 };

--- a/README-de.md
+++ b/README-de.md
@@ -17,7 +17,8 @@ Shariff besteht aus zwei Teilen. Der erste Teil ist eine einfache JavaScript-Bib
     * `build/shariff.complete.css` enthält alle Abhängigkeiten
     * `build/shariff.min.css` verwenden, wenn [Font Awesome](https://github.com/FortAwesome/Font-Awesome) bereits in Ihrer Seite geladen wird
 3. JavaScript unmittelbar vor `</body>` einbinden:
-    * `build/shariff.min.js`
+    * `build/shariff.complete.js` enthält alle Abhängigkeiten
+    * `build/shariff.min.js` verwenden, wenn [jQuery](https://github.com/jquery/jquery) bereits in der Seite vorhanden ist
 4. Beliebig viele `<div class="shariff">` Elemente einfügen
 5. Mit den unten beschriebenen `data`-Attributen Aussehen und Funktion konfigurieren
 
@@ -42,7 +43,7 @@ Code-Beispiel:
     <div class="shariff" data-backend-url="/path/to/backend" data-url="http://www.example.com/my-article.html" data-theme="grey" data-orientation="vertical"></div>
 
     <!-- vor dem schließenden </body>-Tag -->
-    <script src="/path/to/shariff.min.js"></script>
+    <script src="/path/to/shariff.complete.js"></script>
 </body>
 </html>
 ```
@@ -61,7 +62,8 @@ Dann kann Shariff im eigenen Skript initialisiert und an DOM-Elemente gebunden w
 ```js
 // my-app.js
 var Shariff = require('shariff');
-var buttonsContainer = document.querySelector('.some-selector');
+var $ = require('jquery');
+var buttonsContainer = $('.some-selector');
 new Shariff(buttonsContainer, {
     orientation: 'vertical'
 });

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Shariff consists of two parts: a simple JavaScript client library and an optiona
     * `build/shariff.complete.css` contains all dependencies
     * if [Font Awesome](https://github.com/FortAwesome/Font-Awesome) is already included in your site, use `build/shariff.min.css` 
 3. Include JavaScript right before `</body>`:
-    * `build/shariff.min.js`
+    * `build/shariff.complete.js` contains all dependencies
+    * if [jQuery](https://github.com/jquery/jquery) is already included in your site, use `build/shariff.min.js`
 4. Insert one or more `<div class="shariff">` elements.
 5. Customize the look using data-* attributes.
 
@@ -61,7 +62,8 @@ Edit your JS main script, include Shariff and initialize it in one or more conta
 ```js
 // my-app.js
 var Shariff = require('shariff');
-var buttonsContainer = document.querySelector('.some-selector');
+var $ = require('jquery');
+var buttonsContainer = $('.some-selector');
 new Shariff(buttonsContainer, {
     orientation: 'vertical'
 });

--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
     "shariff-backend-node": "^3.0.0",
     "uglifyify": "^3.0.1"
   },
+  "browserify-shim": {
+    "./dom": "global:jQuery"
+  },
   "keywords": [
     "heise",
     "social buttons",

--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -39,7 +39,7 @@ var Shariff = function(element, options) {
 
     // filter available services to those that are enabled and initialize them
     this.services = $.map(this.options.services, function(serviceName) {
-        var service;
+        var service = null;
         availableServices.forEach(function(availableService) {
             availableService = availableService(self);
             if (availableService.name === serviceName) {


### PR DESCRIPTION
Followup to #214 to re-establish the `shariff.complete.js` file.
The js files now contain the content as expected:
- `shariff.complete.js` includes the custom `dom` module
- `shariff.min.js` relies on jQuery to be present
