### PR TITLE
support IE11 -- resolves #220

### DIFF
--- a/src/js/dom.js
+++ b/src/js/dom.js
@@ -1,5 +1,31 @@
 'use strict';
 
+// https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill
+if (typeof Object.assign !== 'function') {
+  // jshint maxdepth:4
+  Object.assign = function(target, varArgs) { // .length of function is 2
+    if (target === null) { // TypeError if undefined or null
+      throw new TypeError('Cannot convert undefined or null to object');
+    }
+
+    var to = Object(target);
+
+    for (var index = 1; index < arguments.length; index++) {
+      var nextSource = arguments[index];
+
+      if (nextSource !== null) { // Skip over if undefined or null
+        for (var nextKey in nextSource) {
+          // Avoid bugs when hasOwnProperty is shadowed
+          if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+            to[nextKey] = nextSource[nextKey];
+          }
+        }
+      }
+    }
+    return to;
+  };
+}
+
 /**
  * Initialization helper. This method is this module's exported entry point.
  * @param {string|Array|Element} selector - css selector, one element, array of nodes or html fragment

--- a/src/js/dom.js
+++ b/src/js/dom.js
@@ -39,7 +39,7 @@ function dq(selector, context) {
     nodes = [ selector ];
   } else if (typeof selector === 'string') {
     if (selector[0] === '<') {
-      nodes = fragment(selector);
+      nodes = Array.prototype.slice.call(fragment(selector));
     } else {
       nodes = Array.prototype.slice.call(context.querySelectorAll(selector));
     }


### PR DESCRIPTION
resolves #220.

- [x] introduces a polyfill for `Object.assign` to counter `Object doesn't support property or method 'assign'`
- [x] ~~use `$.each` instead of `Array.forEach()`~~
- [x] ~~use `String.replace` instead of `ClassList`~~
- [x] work around F12 changing JS behavior -- see #220 

tested on win7 build 7601 sp1 + ie 11.0.9600.17420