### PR TITLE
support dom-ready functions with shariff-native dom library

### DIFF
--- a/src/js/dom.js
+++ b/src/js/dom.js
@@ -35,7 +35,9 @@ if (typeof Object.assign !== 'function') {
 function dq(selector, context) {
   var nodes = [];
   context = context || document;
-  if (selector instanceof Element) {
+  if (typeof selector === 'function') {
+    context.addEventListener('DOMContentLoaded', selector);
+  } else if (selector instanceof Element) {
     nodes = [ selector ];
   } else if (typeof selector === 'string') {
     if (selector[0] === '<') {


### PR DESCRIPTION
this adds support to use the DOM library introduced in #220 to add `DOMContentLoaded` event listeners:

```js
$(function() {
  // code
});
```

this is necessary for code about to be introduced in #213.
