### PR TITLE
Hotfix for issue 230: Pinterest service can never access og:image

### DIFF
--- a/src/js/services/pinterest.js
+++ b/src/js/services/pinterest.js
@@ -9,7 +9,7 @@ module.exports = function(shariff) {
         title += ' - ' + creator;
     }
     var img = shariff.getOption('mediaUrl');
-    if (img && img.length <= 0) {
+    if (!img || img.length <= 0) {
         img = shariff.getMeta('og:image');
     }
 


### PR DESCRIPTION
Issue URL:
https://github.com/heiseonline/shariff/issues/230

Resubmitting because a prior PR was rejected due to build artifacts
https://github.com/heiseonline/shariff/pull/231

The problem was in the file `shariff/src/js/services/pinterest.js`

when no value or an empty string is provided through `data-media-url`, the meta ob:image is supposed to be used as a default.

However, control statement on line 12 is never true
```javascript
if (img && img.length <= 0) {
```
because an empty string is a boolean false, so the code block that pulls out the og:image is never executed.

The statement should be rewritten as follows
```javascript
if (!img || img.length <= 0) {
```

I changed it accordingly.