### PR TITLE
Use self closing tags so sharif works with XHTML/XML mode

### DIFF
--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -203,19 +203,19 @@ Shariff.prototype = {
         var orientationClass = 'orientation-' + this.options.orientation;
         var serviceCountClass = 'col-' + this.options.services.length;
 
-        var $buttonList = $('<ul>').addClass(themeClass).addClass(orientationClass).addClass(serviceCountClass);
+        var $buttonList = $('<ul />').addClass(themeClass).addClass(orientationClass).addClass(serviceCountClass);
 
         // add html for service-links
         this.services.forEach(function(service) {
-            var $li = $('<li class="shariff-button">').addClass(service.name);
-            var $shareText = '<span class="share_text">' + self.getLocalized(service, 'shareText');
+            var $li = $('<li class="shariff-button" />').addClass(service.name);
+            var $shareText = '<span class="share_text" />' + self.getLocalized(service, 'shareText');
 
-            var $shareLink = $('<a>')
+            var $shareLink = $('<a />')
               .attr('href', service.shareUrl)
               .append($shareText);
 
             if (typeof service.faName !== 'undefined') {
-                $shareLink.prepend('<span class="fa ' +  service.faName + '">');
+                $shareLink.prepend('<span class="fa ' +  service.faName + '" />');
             }
 
             if (service.popup) {

--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -208,7 +208,7 @@ Shariff.prototype = {
         // add html for service-links
         this.services.forEach(function(service) {
             var $li = $('<li class="shariff-button" />').addClass(service.name);
-            var $shareText = '<span class="share_text" />' + self.getLocalized(service, 'shareText');
+            var $shareText = '<span class="share_text">' + self.getLocalized(service, 'shareText') + '</span>';
 
             var $shareLink = $('<a />')
               .attr('href', service.shareUrl)


### PR DESCRIPTION
This PR adjusts the way the elements are created to support XHTML/XHTML5.

The strings past in ```$('<foo>')``` are applied to the innerHTML property and thus, when the browser is in XML mode, likely because the content has been served as ```application/xhtml+xml``` or due to the XML header, must be parse-able as XML:
```
XML Parsing Error: mismatched tag. Expected: </ul>.  
SyntaxError: An invalid or illegal string was specified  shariff.min.js:29
```

The change by this PR is simply closing all elements directly. This works fine as all other changes following are going to be added as children or attributes referencing the newly created node.

Tested in Firefox 52+53 (Linux) and Chrome 57 (Linux).
