### PR TITLE
fix against xss problems

### DIFF
--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -105,7 +105,7 @@ Shariff.prototype = {
         services   : ['twitter', 'facebook', 'googleplus', 'info'],
 
         title: function() {
-            return $('head title').text();
+            return $('head title').html();
         },
 
         twitterVia: null,


### PR DESCRIPTION
function .text() will execute code inside the title tag. 
correct is to use .html() which will load the html-code and not execute the code inside <title>


