### PR TITLE
make addClass work in IE

### DIFF
--- a/src/js/dom.js
+++ b/src/js/dom.js
@@ -182,7 +182,12 @@ DOMQuery.prototype.prepend = function(html) {
  * @returns {DOMQuery}
  */
 DOMQuery.prototype.addClass = function(names) {
-  return this.each(function() { this.classList.add(...names.split(' ')) })
+  return this.each(function() {
+    // Workaround: IE only supports a single parameter to classList.add()
+    for (let name of names.split(' ')) {
+      this.classList.add(name)
+    }
+  })
 }
 
 /**


### PR DESCRIPTION
IE only supports a single parameter to `classList.add()`.

This is a workaround for #253, at least for a part if that issue. A proper fix would include allowing to use jquery again.
