### PR TITLE
Added localization support via data-l10n dom attribute

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -97,5 +97,18 @@
             <p>The Big Oxmox advised her not to do so, because there were thousands of bad Commas, wild Question Marks and devious Semikoli, but the Little Blind Text didn’t listen. She packed her seven versalia, put her initial into the belt and made herself on the way. When she reached the first hills of the Italic Mountains, she had a last view back on the skyline of her hometown Bookmarksgrove, the headline of Alphabet Village and the subline of her own road, the Line Lane. </p>
         </section>
     </article>
+    <hr>
+    <dl class="layout-hint">
+        <dt>data-l10n:</dt><dd>{&quot;facebook&quot;:{&quot;shareText&quot;:&quot;Facebook&quot;},&quot;googleplus&quot;:{&quot;shareText&quot;:&quot;Google+&quot;},&quot;twitter&quot;:{&quot;shareText&quot;:&quot;Twitter&quot;}}</dd>
+    </dl>
+    <article class="wide">
+        <h1>Cras lobortis ligula a pretium porta</h1>
+        <aside id="article_extras_l10n">
+            <div class="shariff" data-orientation="horizontal" data-services="[&quot;facebook&quot;,&quot;twitter&quot;,&quot;googleplus&quot;]" data-l10n="{&quot;facebook&quot;:{&quot;shareText&quot;:&quot;Facebook&quot;},&quot;googleplus&quot;:{&quot;shareText&quot;:&quot;Google+&quot;},&quot;twitter&quot;:{&quot;shareText&quot;:&quot;Twitter&quot;}}"></div>
+        </aside>
+        <section id="article_content_l10n">
+            <p>Aliquam congue lectus vitae laoreet viverra. Vivamus pellentesque urna odio, ut ullamcorper dui posuere eu. Phasellus vitae sodales erat. Proin et venenatis ligula. Integer aliquet bibendum est, ut vestibulum odio sollicitudin et. Aenean pellentesque eget diam sit amet mollis. Proin tincidunt sodales massa a imperdiet. Interdum et malesuada fames ac ante ipsum primis in faucibus. Donec iaculis consequat purus, rhoncus scelerisque ligula consequat quis. Nullam eu enim accumsan, tristique metus eget, posuere tortor. Cras lobortis ligula a pretium porta. Vestibulum aliquet, magna a pharetra feugiat, nisi diam tristique ligula, ac bibendum ex dui varius erat.</p>
+        </section>
+    </article>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
     {
       "name": "Deniz Sesli",
       "email": "dzs@heise.de"
+    },
+    {
+      "name": "Alexander Buch",
+      "email": "alexander.buch@cartware.de"
     }
   ],
   "dependencies": {

--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -106,6 +106,16 @@ class Shariff {
 
   getLocalized(data, key) {
     if (typeof data[key] === 'object') {
+      if (typeof data.name !== 'undefined') {
+        let serviceName = data.name;
+        if (typeof this.options['l10n'] == 'object'
+          && typeof this.options.l10n[serviceName] !== 'undefined'
+          && typeof this.options.l10n[serviceName][key] !== 'undefined'
+        ) {
+          return this.options.l10n[serviceName][key];
+        }
+      }
+      
       if (typeof data[key][this.options.lang] === 'undefined') {
         return data[key][this.options.langFallback]
       } else {


### PR DESCRIPTION
Services lack a mechanism to have custom labels for `title` and `shareText` which might be provided server-side. I therefor expanded the `options` for a `l10n`-key which is an object overriding the services title/shareText if provided.