### PR TITLE
Compatibility to WordPress Theme Twentyseventeen

### DIFF
--- a/src/style/shariff-layout.less
+++ b/src/style/shariff-layout.less
@@ -27,6 +27,8 @@
         height: 35px;
         box-sizing: border-box;
         overflow: hidden;
+        padding: 0;
+        border: none;
         a {
             color: #fff;
             position: relative;


### PR DESCRIPTION
Wordpress theme "Twentyseventeen" declares li-Elements in .widget-Containers to have a padding, which makes the buttons look smaller than they should.