### PR TITLE
Add missing documentation for info service

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -87,6 +87,7 @@ $ npm run dev
 | `data-backend-url` | Pfad zum Shariff-[Backend](#backends). Der Wert `null` deaktiviert die Anzeige von Share-Counts.  | `null` |
 | `data-flattr-category` | Kategorie für Flattr-Spende. | `null` |
 | `data-flattr-user` | Benutzer, der die Flattr-Spende erhält. | `null` |
+| `data-info-url` | URL of the info page. | `http://ct.de/-2467514` |
 | `data-lang`      | Lokalisierung auswählen. Verfügbar: `bg`, `de`, `en`, `es`, `fi`, `hr`, `hu`, `ja`, `ko`, `no`, `pl`, `pt`, `ro`, `ru`, `sk`, `sl`, `sr`, `sv`, `tr`, `zh` | `de` |
 | `data-mail-body` | Wenn `data-mail-url` ein `mailto:`-Link ist, wird dieser Wert als Mail-Body verwendet. Der Mail-Body-Text sollte den Platzhalter `{url}` enthalten. Dieser wird durch die zu teilende URL ersetzt. | siehe `data-url` |
 | `data-mail-subject` | Wenn `data-mail-url` ein `mailto:`-Link ist, wird dieser Wert als Mail-Betreff verwendet. | siehe `data-title` |
@@ -147,6 +148,9 @@ Shariff unterstützt folgende Social-Sharing-Services:
 - Weibo
 - WhatsApp
 - XING
+
+Zusätzlich stellt der Service `Info` einen Button zur Anzeige einer Infoseite über die Social-Sharing-Buttons bereit.
+Die URL dieser Seite kann mit einer Option festgelegt werden. Standardwert: `http://ct.de/-2467514`, d.h. der c't-Artikel zur Einführung von Shariff.
 
 ## Backends
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ $ npm run dev
 | `data-backend-url` | The path to your Shariff backend, see below. Settings the value to `null` disables the backend feature. No counts will occur.  | `null` |
 | `data-flattr-category` | Category to be used for Flattr. | `null` |
 | `data-flattr-user` | User that receives Flattr donation. | `null` |
+| `data-info-url` | URL of the info page. | `http://ct.de/-2467514` |
 | `data-lang`      | The localisation to use. Available: `bg`, `de`, `en`, `es`, `fi`, `hr`, `hu`, `ja`, `ko`, `no`, `pl`, `pt`, `ro`, `ru`, `sk`, `sl`, `sr`, `sv`, `tr`, `zh` | `de` |
 | `data-mail-body` | If a `mailto:` link is used in `data-mail-url`, then this value is used as the mail body. The body text should contain the placeholder `{url}` which will be replaced with the share URL. | see `data-url`  |
 | `data-mail-subject` | If a `mailto:` link is used in `data-mail-url`, then this value is used as the mail subject. | see `data-title` |
@@ -149,6 +150,9 @@ Shariff supports the following social sharing services:
 - Weibo
 - WhatsApp
 - XING
+
+In addition, the service `Info` provides a button to show an info page about the social sharing buttons.
+The URL of this page can be set with an option. Default value: `http://ct.de/-2467514`, i.e. the c't article introducing Shariff. 
 
 ## Backends
 


### PR DESCRIPTION
Add data-info-url to the table of options, add information about info service to supported services section.

Currently the info service just listed in the options table for the data-services option, but it is nowhere further explained, and the option data-info-url is missing in the options table, too.

Testing: By review.