### PR TITLE
Enhancement: New option infoDisplay (data-info-display) to control display of the info page

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -88,6 +88,7 @@ $ npm run dev
 | `data-flattr-category` | Kategorie für Flattr-Spende. | `null` |
 | `data-flattr-user` | Benutzer, der die Flattr-Spende erhält. | `null` |
 | `data-info-url` | URL der Infoseite. | `http://ct.de/-2467514` |
+| `data-info-display` | Display-Art der Infoseite. Werte: `blank`, `popup`, `self` | `blank` |
 | `data-lang`      | Lokalisierung auswählen. Verfügbar: `bg`, `de`, `en`, `es`, `fi`, `hr`, `hu`, `ja`, `ko`, `no`, `pl`, `pt`, `ro`, `ru`, `sk`, `sl`, `sr`, `sv`, `tr`, `zh` | `de` |
 | `data-mail-body` | Wenn `data-mail-url` ein `mailto:`-Link ist, wird dieser Wert als Mail-Body verwendet. Der Mail-Body-Text sollte den Platzhalter `{url}` enthalten. Dieser wird durch die zu teilende URL ersetzt. | siehe `data-url` |
 | `data-mail-subject` | Wenn `data-mail-url` ein `mailto:`-Link ist, wird dieser Wert als Mail-Betreff verwendet. | siehe `data-title` |

--- a/README-de.md
+++ b/README-de.md
@@ -88,7 +88,7 @@ $ npm run dev
 | `data-flattr-category` | Kategorie für Flattr-Spende. | `null` |
 | `data-flattr-user` | Benutzer, der die Flattr-Spende erhält. | `null` |
 | `data-info-url` | URL der Infoseite. | `http://ct.de/-2467514` |
-| `data-info-display` | Display-Art der Infoseite. Werte: `blank`, `popup`, `self` | `blank` |
+| `data-info-display` | Wie die Infoseite angezeigt wird. Werte: `blank`, `popup`, `self`. | `blank` |
 | `data-lang`      | Lokalisierung auswählen. Verfügbar: `bg`, `de`, `en`, `es`, `fi`, `hr`, `hu`, `ja`, `ko`, `no`, `pl`, `pt`, `ro`, `ru`, `sk`, `sl`, `sr`, `sv`, `tr`, `zh` | `de` |
 | `data-mail-body` | Wenn `data-mail-url` ein `mailto:`-Link ist, wird dieser Wert als Mail-Body verwendet. Der Mail-Body-Text sollte den Platzhalter `{url}` enthalten. Dieser wird durch die zu teilende URL ersetzt. | siehe `data-url` |
 | `data-mail-subject` | Wenn `data-mail-url` ein `mailto:`-Link ist, wird dieser Wert als Mail-Betreff verwendet. | siehe `data-title` |

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ npm run dev
 | `data-flattr-category` | Category to be used for Flattr. | `null` |
 | `data-flattr-user` | User that receives Flattr donation. | `null` |
 | `data-info-url` | URL of the info page. | `http://ct.de/-2467514` |
-| `data-info-display` | Display type of the info page. Values: `blank`, `popup`, `self` | `blank` |
+| `data-info-display` | How to display the info page. Values: `blank`, `popup`, `self`. | `blank` |
 | `data-lang`      | The localisation to use. Available: `bg`, `de`, `en`, `es`, `fi`, `hr`, `hu`, `ja`, `ko`, `no`, `pl`, `pt`, `ro`, `ru`, `sk`, `sl`, `sr`, `sv`, `tr`, `zh` | `de` |
 | `data-mail-body` | If a `mailto:` link is used in `data-mail-url`, then this value is used as the mail body. The body text should contain the placeholder `{url}` which will be replaced with the share URL. | see `data-url`  |
 | `data-mail-subject` | If a `mailto:` link is used in `data-mail-url`, then this value is used as the mail subject. | see `data-title` |

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ $ npm run dev
 | `data-flattr-category` | Category to be used for Flattr. | `null` |
 | `data-flattr-user` | User that receives Flattr donation. | `null` |
 | `data-info-url` | URL of the info page. | `http://ct.de/-2467514` |
+| `data-info-display` | Display type of the info page. Values: `blank`, `popup`, `self` | `blank` |
 | `data-lang`      | The localisation to use. Available: `bg`, `de`, `en`, `es`, `fi`, `hr`, `hu`, `ja`, `ko`, `no`, `pl`, `pt`, `ro`, `ru`, `sk`, `sl`, `sr`, `sv`, `tr`, `zh` | `de` |
 | `data-mail-body` | If a `mailto:` link is used in `data-mail-url`, then this value is used as the mail body. The body text should contain the placeholder `{url}` which will be replaced with the share URL. | see `data-url`  |
 | `data-mail-subject` | If a `mailto:` link is used in `data-mail-url`, then this value is used as the mail subject. | see `data-title` |

--- a/src/js/services/info.js
+++ b/src/js/services/info.js
@@ -2,8 +2,8 @@
 
 module.exports = function(shariff) {
   return {
-    blank: true,
-    popup: false,
+    blank: shariff.getInfoDisplayBlank(),
+    popup: shariff.getInfoDisplayPopup(),
     shareText: 'Info',
     name: 'info',
     faName: 'fa-info',

--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -131,13 +131,13 @@ class Shariff {
   }
 
   getInfoDisplayPopup() {
-    return (this.options.infoDisplay.toLowerCase() === 'popup')
+    return (this.options.infoDisplay === 'popup')
   }
 
   getInfoDisplayBlank() {
     return (
-      (this.options.infoDisplay.toLowerCase() !== 'popup') &&
-      (this.options.infoDisplay.toLowerCase() !== 'self')
+      (this.options.infoDisplay !== 'popup') &&
+      (this.options.infoDisplay !== 'self')
     )
   }
 

--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -17,6 +17,9 @@ const Defaults = {
   // Link to the "about" page
   infoUrl: 'http://ct.de/-2467514',
 
+  // Type of display for the "about" page: "blank", "popup" or "self", default = "blank"
+  infoDisplay: 'blank',
+
   // localisation: "de" or "en"
   lang: 'de',
 
@@ -125,6 +128,17 @@ class Shariff {
 
   getInfoUrl() {
     return this.options.infoUrl
+  }
+
+  getInfoDisplayPopup() {
+    return (this.options.infoDisplay.toLowerCase() === 'popup')
+  }
+
+  getInfoDisplayBlank() {
+    return (
+      (this.options.infoDisplay.toLowerCase() !== 'popup') &&
+      (this.options.infoDisplay.toLowerCase() !== 'self')
+    )
   }
 
   getURL() {


### PR DESCRIPTION
**Description**

This PR adds a new option infoDisplay (data-info-display) which allows to control how the info page (service = "info") is shown:

- "blank" shows the info page in a new window or browser tab (depending on the browser settings). This is the current behavior.
- "popup" shows the info page in a new small browser window which looks like a dialog, like the sharing links do it now.
- "self" uses the current browser window and tab.

The reason for this PR is that depending on which kind of URL is specified with the data-info-url parameter, different behaviors are most appropriate:

- If the URL is for an external website like the default link to the c't article is, "blank" is the most appropriate.
- If the URL is an internal one, "self" is more appropriate than "blank", and if the content is only a little information, "popup" might be the most appropriate.

For backwards compatibility the default is "blank", and any invalid value (data-info-display="gaga") also results in "blank".

**How to test:**

1. Don't specify data-info-display. Result: Info page is shown in a new browser tab like without this PR.
2. Specify data-info-display="self". Result: Info page is shown in the current browser tab.
3. Specify data-info-display="popup". Result: Info page is shown in a dialog like the sharing dialogs are.
4. Specify data-info-display="blank". Result: Info page is shown in a new browser tab like without this PR.
5. Specify data-info-display="anythingelse" (or "blabla" or "gaga" ...). Result: Info page is shown in a new browser tab like without this PR.

**Details on the implementation:**

This PR uses the existing method to control display for the services, i.e. the 2 booleans "blank" and "popup" of the info service, which are checked in shariff.js in lines 244 to 248 to set the link target or data-rel attribute:

> if (service.popup) {
>   $shareLink.attr('data-rel', 'popup')
> } else if (service.blank) {
>   $shareLink.attr('target', '_blank')
> }

So if both booleans are false, no link target and no data-rel="popup" are set, which results in the default target "_self".

And so the only thing to do in code is to set these 2 booleans according to the new parameter:

- "blank" => popup=false, blank=true (like they are set now without this PR)
- "popup" => popup=true, blank=false (like they are set for other sharing services)
- "self" => popup=false, blank=false

And of course the readme docs are updated by this PR, too.