### PR TITLE
Security issue: Add rel="noopener noreferrer" to hyperlinks if target="_blank"

### DIFF
--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -198,6 +198,7 @@ class Shariff {
         $shareLink.attr('data-rel', 'popup')
       } else if (service.blank) {
         $shareLink.attr('target', '_blank')
+        $shareLink.attr('rel', 'noopener noreferrer')
       }
       $shareLink.attr('title', this.getLocalized(service, 'title'))
 


### PR DESCRIPTION
Add rel="noopener noreferrer" to the sharing and info hyperlinks if target="_blank".

Hyperlinks with target="_blank" and not having rel="noopener" are both a security and a performance issue, see [https://developers.google.com/web/tools/lighthouse/audits/noopener](https://developers.google.com/web/tools/lighthouse/audits/noopener) for details. The Google site auditing tool "lighthouse" reports this as a security and a performance issue.

For compatibility with older Firefox versions who do not understand the rel="noopener" but the rel="noreferrer", both can be combined to rel="noopener noreferrer", see e.g. [https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/](https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/) for details.

**How to test this PR:** By review, or build a shariff with this PR included and then check with the info page service that the hyperlink has rel="noopener noreferrer".