### PR TITLE
Remove twitter backend from docs and demo

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -4,11 +4,11 @@ Um die Privatsphäre ihrer Besucher gegenüber den Social-Media-Netzwerken zu be
 
 ![Shariff Logo © 2015 Heise Medien](http://www.heise.de/icons/ho/shariff-logo.png)
 
-Der Code der offiziellen Buttons von Facebook, Google+ und Twitter überträgt von jedem Besucher kennzeichnende Daten an die Social-Media-Netzwerke. Shariff erzeugtze hingegen Share-Buttons, die mit einem Klick teilen, die Anzahl der Likes, Tweets und Plus-Ones für die aktuelle Seite anzeigen und trotzdem keine unnötigen Daten übertragen.
+Der Code der offiziellen Buttons von Facebook, Google+ und Twitter überträgt von jedem Besucher kennzeichnende Daten an die Social-Media-Netzwerke. Shariff erzeugt hingegen Share-Buttons, die mit einem Klick teilen, die Anzahl der Likes und Plus-Ones für die aktuelle Seite anzeigen und trotzdem keine unnötigen Daten übertragen.
 
 Shariff `(/ˈʃɛɹɪf/)` ist ein Open-Source Projekt von c't und heise online.
 
-Shariff besteht aus zwei Teilen. Der erste Teil ist eine einfache JavaScript-Bibliothek einschließlich Vektor-Icons und CSS zur Formatierung der Knöpfe. Der zweite ist die optionale, server-seitige Komponente (derzeit für PHP, Perl oder NodeJS). Mit dem Shariff-Backend auf dem eigenen Server muss der Browser des Besuchers zur Darstellung der Share-Counts keine Verbindung zu Facebook, Twitter oder Google+ aufbauen. Daten werden erst dann zum Social-Media-Netzwerk übertragen, wenn der Besucher den Inhalt tatsächlich teilen möchte.
+Shariff besteht aus zwei Teilen. Der erste Teil ist eine einfache JavaScript-Bibliothek einschließlich Vektor-Icons und CSS zur Formatierung der Knöpfe. Der zweite ist die optionale, server-seitige Komponente (derzeit für PHP, Perl oder NodeJS). Mit dem Shariff-Backend auf dem eigenen Server muss der Browser des Besuchers zur Darstellung der Share-Counts keine Verbindung zu Facebook oder Google+ aufbauen. Daten werden erst dann zum Social-Media-Netzwerk übertragen, wenn der Besucher den Inhalt tatsächlich teilen möchte.
 
 ## Erste Schritte
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Facebook, Google+ and Twitter supply official sharing code snippets which quietl
 
 Shariff `(/ˈʃɛɹɪf/)` is an open-source, low-maintenance, high-privacy solution maintained by German computer magazine c't and heise online.
 
-Shariff consists of two parts: a simple JavaScript client library and an optional server-side component. The latter fetches the number of likes, tweets and plus-ones. Share buttons and share counts work without a connection between your visitors' browsers and *social networks* (unless they decide to share, of course).
+Shariff consists of two parts: a simple JavaScript client library and an optional server-side component. The latter fetches the number of likes and plus-ones. Share buttons and share counts work without a connection between your visitors' browsers and *social networks* (unless they decide to share, of course).
 
 ## Getting Started
 

--- a/demo/backend.json
+++ b/demo/backend.json
@@ -1,1 +1,1 @@
-{"facebook":0,"googleplus":3387,"linkedin":92,"reddit":12,"stumbleupon":4325,"xing":185,"twitter":4120}
+{"facebook":0,"googleplus":3387,"linkedin":92,"reddit":12,"stumbleupon":4325,"xing":185}


### PR DESCRIPTION
After Twitter had discontinued their share count API, the Twitter service has been removed from shariff-backend-php in November 2015, see [https://github.com/heiseonline/shariff-backend-php/pull/48]( https://github.com/heiseonline/shariff-backend-php/pull/48). (Other backends might be maintained less well and so still contain the Twitter service.)

This PR removes references to the Twitter count in documents and removes the twitter service from the backend dummy of the demo.

Beside this, it corrects a typo in the German doc: "... Shariff erzeugt**ze** hingegen Share-Buttons ..."

**How to test:** By review.

Additional note: It might be necessary in near future to do the same for the Google service, because it seems they have also discontinued tracking and counting of plusones and shares in their API, or at least it might need an API key different to the public one used by shariff-backend-php. If I find time I will check that and if necessary provide a PR to shariff-backend-php, and if that results in the google service being removed from the backend, I would provide a PR for that here, similar to this one.