### PR TITLE
Correct errors in listings of options on the demo page

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -39,7 +39,6 @@
     <hr>
     <dl class="layout-hint">
         <dt>data-backend-url:</dt><dd>/shariff/</dd>
-        <dt>data-info-url:</dt><dd>http://example.com</dd>
         <dt>data-lang:</dt><dd>en</dd>
         <dt>data-mail-url:</dt><dd>mailto:foo@example.com</dd>
         <dt>data-title:</dt><dd>Lorem ipsum</dd>

--- a/demo/index.html
+++ b/demo/index.html
@@ -44,6 +44,7 @@
         <dt>data-mail-url:</dt><dd>mailto:foo@example.com</dd>
         <dt>data-title:</dt><dd>Lorem ipsum</dd>
         <dt>data-url:</dt><dd>http://www.heise.de/ct/</dd>
+        <dt>data-services:</dt><dd>[&amp;quot;whatsapp&amp;quot;,&amp;quot;facebook&amp;quot;,&amp;quot;twitter&amp;quot;,&amp;quot;googleplus&amp;quot;,&amp;quot;mail&amp;quot;,&amp;quot;info&amp;quot;]</dd>
     </dl>
     <article class="slim">
         <header>
@@ -61,6 +62,7 @@
         <dt>data-theme:</dt><dd>grey</dd>
         <dt>data-twitter-via:</dt><dd>heiseonline</dd>
         <dt>data-url:</dt><dd>http://www.heise.de/ct/</dd>
+        <dt>data-services:</dt><dd>[&amp;quot;facebook&amp;quot;,&amp;quot;twitter&amp;quot;,&amp;quot;googleplus&amp;quot;,&amp;quot;whatsapp&amp;quot;,&amp;quot;info&amp;quot;]</dd>
     </dl>
     <article class="slim">
         <header>
@@ -74,6 +76,7 @@
     <dl class="layout-hint">
         <dt>data-backend-url:</dt><dd>/shariff/</dd>
         <dt>data-theme:</dt><dd>white</dd>
+        <dt>data-services:</dt><dd>[&amp;quot;facebook&amp;quot;,&amp;quot;twitter&amp;quot;,&amp;quot;googleplus&amp;quot;,&amp;quot;mail&amp;quot;,&amp;quot;info&amp;quot;]</dd>
     </dl>
     <article class="slim">
         <header>

--- a/demo/index.html
+++ b/demo/index.html
@@ -26,7 +26,7 @@
         <dt>data-backend-url:</dt><dd>/shariff/</dd>
         <dt>data-media-url:</dt><dd>http://www.heise.de/imgs/18/1/4/8/0/5/6/9/wa-encryption-d1999f774c5b5757.png</dd>
         <dt>data-flattr-user:</dt><dd>example</dd>
-        <dt>data-services:</dt><dd>[&amp;quot;addthis&amp;quot;,whatsapp&amp;quot;,&amp;quot;facebook&amp;quot;,&amp;quot;xing&amp;quot;,&amp;quot;pinterest&amp;quot;,&amp;quot;linkedin&amp;quot;,&amp;quot;tumblr&amp;quot;,&amp;quot;flattr&amp;quot;,&amp;quot;diaspora&amp;quot;,&amp;quot;reddit&amp;quot;,&amp;quot;stumbleupon&amp;quot;,&amp;quot;threema&amp;quot;,&amp;quot;weibo&amp;quot;,&amp;quot;tencent-weibo&amp;quot;,&amp;quot;qzone&amp;quot;,&amp;quot;print&amp;quot;]</dd>
+        <dt>data-services:</dt><dd>[&amp;quot;addthis&amp;quot;,&amp;quot;whatsapp&amp;quot;,&amp;quot;facebook&amp;quot;,&amp;quot;xing&amp;quot;,&amp;quot;pinterest&amp;quot;,&amp;quot;linkedin&amp;quot;,&amp;quot;tumblr&amp;quot;,&amp;quot;flattr&amp;quot;,&amp;quot;diaspora&amp;quot;,&amp;quot;reddit&amp;quot;,&amp;quot;stumbleupon&amp;quot;,&amp;quot;threema&amp;quot;,&amp;quot;weibo&amp;quot;,&amp;quot;tencent-weibo&amp;quot;,&amp;quot;qzone&amp;quot;,&amp;quot;print&amp;quot;]</dd>
     </dl>
     <article class="slim">
         <header>


### PR DESCRIPTION
This PR corrects following 3 issues in the demo main page "demo/index.html":

1. In the parameters listing for the "data-services" parameter of the 2nd example (which is the first one with parameters) one "&amp;quot;" is missing before "whatsapp". See attached screen shot of the [Shariff demo](http://heiseonline.github.io/shariff/).

![shariff-demo-ampersand-error](https://user-images.githubusercontent.com/7413183/34326679-88d15458-e8b3-11e7-99bc-f5b960198541.png)


2. Examples 3, 4 and 5 use the "data-services" parameter, but this is not listed in the parameters listings for these examples.

3. Example 3 does not use the "data-info-url" parameter, but it is shown in the parameters listing for that example.

I have made these 3 changes with 3 commits, so maintainers can decide to cherry-pick some of these 3 changes only, e.g. in case if the 2nd issue is not a mistake but by purpose because only changed parameters compared to previous examples should be listed in the description.

**How to test:** Run the demo as described in the README and using the index-html from this PR.

**Expected results:**

Issue 1: The "data-services" parameter in the parameters listing of the 2nd example shows the correct encoded html, and the listing shows the same value as used for the shariff element in that example.

Issue 2: The "data-services" parameter in the parameters listing of examples 3, 4 and 5 show the same values as used for the shariff elements for the particular examples.

Issue 3: The "data-info-url" parameter is not shown in the parameters listing of examples 3 because it is not used for the shariff elements for that example.