### PR TITLE
Add rel="nofollow" to all sharing buttons' links

### DIFF
--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -210,9 +210,18 @@ class Shariff {
 
       if (service.popup) {
         $shareLink.attr('data-rel', 'popup')
+        if (service.name !== 'info') {
+          $shareLink.attr('rel', 'nofollow')
+        }
       } else if (service.blank) {
         $shareLink.attr('target', '_blank')
-        $shareLink.attr('rel', 'noopener noreferrer')
+        if (service.name === 'info') {
+          $shareLink.attr('rel', 'noopener noreferrer')
+        } else {
+          $shareLink.attr('rel', 'nofollow noopener noreferrer')
+        }
+      } else if (service.name !== 'info') {
+        $shareLink.attr('rel', 'nofollow')
       }
       $shareLink.attr('title', this.getLocalized(service, 'title'))
 


### PR DESCRIPTION
Add rel="nofollow" to all sharing buttons' links, i.e. the links of all buttons except of the "info" button, for better SEO.

See also [https://www.heise.de/forum/c-t/c-t-Shariff-1-Klick-fuer-mehr-Datenschutz/NoFollow-Attribut/thread-4058897/](https://www.heise.de/forum/c-t/c-t-Shariff-1-Klick-fuer-mehr-Datenschutz/NoFollow-Attribut/thread-4058897/).

`AddThis` also recommend this for sharing links, see [https://www.addthis.com/academy/addthis-sharing-endpoints/](https://www.addthis.com/academy/addthis-sharing-endpoints/), note at the end of the overview section:

> We strongly recommend adding rel="nofollow" attributes to your HTML tags, otherwise search engine crawlers who follow your sharing api links can generate false shares in your analytics reports.

How to test: Either code review, or build Shariff with this PR included and then run the demo and check if all links except of the one for the `info` service have a rel attrubute which includes "nofollow", and check if the links are still valid HTML.