### PR TITLE
add data-theme for small icons

### DIFF
--- a/src/js/services/telegram.js
+++ b/src/js/services/telegram.js
@@ -4,7 +4,7 @@ module.exports = function(shariff) {
   var url = encodeURIComponent(shariff.getURL())
 
   return {
-    popup: false,
+    popup: true,
     shareText: {
       'bg': 'cподеляне',
       'da': 'del',


### PR DESCRIPTION
please add a new theme to use smaller icons.

e.g. just square icons without the "share" text. or round icons without the text.

So the usage of many buttons would take less space.