### PR TITLE
Remove GooglePlus share count from demo and docs, update demo Facebook counter, add demo VK counter

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -8,7 +8,7 @@ Der Code der offiziellen Buttons von Facebook, Google+ und Twitter überträgt v
 
 Shariff `(/ˈʃɛɹɪf/)` ist ein Open-Source Projekt von c't und heise online.
 
-Shariff besteht aus zwei Teilen. Der erste Teil ist eine einfache JavaScript-Bibliothek einschließlich Vektor-Icons und CSS zur Formatierung der Knöpfe. Der zweite ist die optionale, server-seitige Komponente (derzeit für PHP, Perl oder NodeJS). Mit dem Shariff-Backend auf dem eigenen Server muss der Browser des Besuchers zur Darstellung der Share-Counts keine Verbindung zu Facebook oder Google+ aufbauen. Daten werden erst dann zum Social-Media-Netzwerk übertragen, wenn der Besucher den Inhalt tatsächlich teilen möchte.
+Shariff besteht aus zwei Teilen. Der erste Teil ist eine einfache JavaScript-Bibliothek einschließlich Vektor-Icons und CSS zur Formatierung der Knöpfe. Der zweite ist die optionale, server-seitige Komponente (derzeit für PHP, Perl oder NodeJS). Mit dem Shariff-Backend auf dem eigenen Server muss der Browser des Besuchers zur Darstellung der Share-Counts keine Verbindung zu den Social-Media-Netzwerken aufbauen. Daten werden erst dann übertragen, wenn der Besucher den Inhalt tatsächlich teilen möchte.
 
 ## Erste Schritte
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Facebook, Google+ and Twitter supply official sharing code snippets which quietl
 
 Shariff `(/ˈʃɛɹɪf/)` is an open-source, low-maintenance, high-privacy solution maintained by German computer magazine c't and heise online.
 
-Shariff consists of two parts: a simple JavaScript client library and an optional server-side component. The latter fetches the number of likes and plus-ones. Share buttons and share counts work without a connection between your visitors' browsers and *social networks* (unless they decide to share, of course).
+Shariff consists of two parts: a simple JavaScript client library and an optional server-side component. The latter fetches the number of likes or shares. Share buttons and share counts work without a connection between your visitors' browsers and *social networks* (unless they decide to share, of course).
 
 ## Getting Started
 

--- a/demo/backend.json
+++ b/demo/backend.json
@@ -1,1 +1,1 @@
-{"facebook":0,"linkedin":92,"reddit":12,"stumbleupon":4325,"xing":185}
+{"facebook":906,"linkedin":92,"reddit":12,"stumbleupon":4325,"vk":57,"xing":185}

--- a/demo/backend.json
+++ b/demo/backend.json
@@ -1,1 +1,1 @@
-{"facebook":0,"googleplus":3387,"linkedin":92,"reddit":12,"stumbleupon":4325,"xing":185}
+{"facebook":0,"linkedin":92,"reddit":12,"stumbleupon":4325,"xing":185}


### PR DESCRIPTION
In June 2017, Google announced that their Share button will not show any counts anymore in order to speed up loading.

Details see [https://github.com/heiseonline/shariff-backend-php/pull/132](https://github.com/heiseonline/shariff-backend-php/pull/132).

This pull request (PR) here removes the counter for GooglePlus from the demo's dummy backend `backend.json` and changes the readme docs so they don't mention that counter anymore.

In addition, a counter for the new VK service has been added to `backend.json`, and the Facebook counter has been updated to a value greater than zero in `backend.json`.

How to test: Code review for docs, also code review or run the demo for the demo.