### PR TITLE
Correct handling of data-mail-subject

### DIFF
--- a/src/js/services/mail.js
+++ b/src/js/services/mail.js
@@ -5,7 +5,7 @@ module.exports = function(shariff) {
 
   // mailto: link? Add body and subject.
   if (url.indexOf('mailto:') === 0) {
-    url += '?subject=' + encodeURIComponent(shariff.getTitle())
+    url += '?subject=' + encodeURIComponent(shariff.getOption('mailSubject') || shariff.getTitle())
     url += '&body=' + encodeURIComponent(shariff.getOption('mailBody').replace(/\{url\}/i, shariff.getURL()))
   }
 


### PR DESCRIPTION
Pull request (PR) for issue #290 .

Handle `data-mail-subject` as described in readme docs:

- If `data-mail-url` is a `mailto:` link and `data-mail-subject` is defined, use value of `data-mail-subject` as mail subject.
- If `data-mail-url` is a `mailto:` link and `data-mail-subject` is not defined, use value of `data-title` or its default as mail subject.
- If `data-mail-url` is **not** a `mailto:` link, don't use the `data-mail-subject` option.

How to test:
1. Code review.
2. Build Shariff with the change of this PR included, or use one of the packages linked below, and test with and without data-mail-subject option.

Packages of Shariff 2.1.2 plus this PR for the 2nd test can be found here:

[https://test5.richard-fath.de/shariff-2.1.2-test-pr291.tar.gz](https://test5.richard-fath.de/shariff-2.1.2-test-pr291.tar.gz)
[https://test5.richard-fath.de/shariff-2.1.2-test-pr291.zip](https://test5.richard-fath.de/shariff-2.1.2-test-pr291.zip)

