### PR TITLE
Change reddit icon to fa-reddit-alien

### DIFF
--- a/src/js/services/reddit.js
+++ b/src/js/services/reddit.js
@@ -17,7 +17,7 @@ module.exports = function(shariff) {
       'zh': '分享',
     },
     name: 'reddit',
-    faName: 'fa-reddit',
+    faName: 'fa-reddit-alien',
     title: {
       'cs': 'Sdílet na Redditu',
       'de': 'Bei Reddit teilen',


### PR DESCRIPTION
Pull request (OR) for issue #292

The normal reddit icon (fa-reddit) is very small and so hard to recognize.

Icon reddit-alien (fa-reddit-alien) is a bit bigger and so the details can be viewn better.

Thanks to @koelling for the hint.

See here the current icon:

![shariff-reddit-old](https://user-images.githubusercontent.com/7413183/36273519-01bc606a-1285-11e8-99f1-cd203eca8dbc.png)

And here the one proposed by this PR:

![shariff-reddit-new](https://user-images.githubusercontent.com/7413183/36273537-0dac4052-1285-11e8-8283-a5d6df0735d2.png)
