### PR TITLE
Use global.document.title as default title

### DIFF
--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -47,9 +47,7 @@ const Defaults = {
   // services to be enabled in the following order
   services: ['twitter', 'facebook', 'googleplus', 'info'],
 
-  title: function() {
-    return $('head title').text()
-  },
+  title: global.document.title,
 
   twitterVia: null,
 


### PR DESCRIPTION
Use global.document.title as default title and not jquery so Shariff javascript does not crash when the html document does not have a `<title>` tag in its head.

Pull request for issue #294 .

**How to test:**

Step 1: Run the shariff demo site locally on a linux host as described [here in the README.md](https://github.com/heiseonline/shariff#running-demo-site) and checking the result with URL=http://localhost:3000/ in a local browser.

Result: Demo works. In 3rd example, the title from opzion `data-title` is used, in the other examples the default value is used, which is the value of the `<DC.title>` tag. You can check that with the Twitter sharing dialog.

Step 2: Remove the complete `<title>` tag from file ./demo/index.html and run again `npm run dev` and check the result.

Result: Demo crashes, no Shariff buttons shown.

Step 3: Edit ./src/js/shariff.js as proposed by this pull request here and run again `npm run dev` and check the result.

Result: Same result as step 1, demo works.

Step 4: Remove the `<DC.title>` tag from ./demo/index.html and run again `npm run dev` and check the result.

Result: Demo works. In 3rd example, the title from opzion `data-title` is used, no title added in Twitter sharing dialog in other examples.

Step 5: Add back the `<title>` tag to ./demo/index.html and run again `npm run dev` and check the result.

Result: Demo works In 3rd example, the title from opzion `data-title` is used,  the value of the `<title>` tag is used in the Twitter dialog in other examples.

Overall result: This PR makes Shariff javascript not crash when the `<title>` is missing in the html document head, and it does not change behavior as described in the README docs.

