### PR TITLE
Update font awesome to free webfonts version v1.0.3, which comes from Font Awesome v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3757,10 +3757,10 @@
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
       "dev": true
     },
-    "font-awesome": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
+    "@fortawesome/fontawesome-free-webfonts": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free-webfonts/-/fontawesome-free-webfonts-1.0.3.tgz",
+      "integrity": "sha512-ZWCFi5hly41jWbVmpmfx97WoGh/8dMDQknrFL6Ax7T7ht4AIZOYL7dmLfrVVI8vsml7VCZvKSImLeHubHbyDQA=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     }
   ],
   "dependencies": {
-    "@fortawesome/fontawesome-free-webfonts": "^1.1.3",
+    "@fortawesome/fontawesome-free-webfonts": "^1.0.3",
     "jquery": "^3.2.1"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     }
   ],
   "dependencies": {
-    "font-awesome": "^4.3.0",
+    "@fortawesome/fontawesome-free-webfonts": "^1.1.3",
     "jquery": "^3.2.1"
   },
   "publishConfig": {

--- a/src/js/services/addthis.js
+++ b/src/js/services/addthis.js
@@ -32,6 +32,7 @@ module.exports = function(shariff) {
       'zh': '分享'
     },
     name: 'addthis',
+    faPrefix: 'fas',
     faName: 'fa-plus',
     title: {
       'bg': 'Сподели в AddThis',

--- a/src/js/services/diaspora.js
+++ b/src/js/services/diaspora.js
@@ -39,6 +39,7 @@ module.exports = function(shariff) {
       'zh': '分享'
     },
     name: 'diaspora',
+    faPrefix: 'fas',
     faName: 'fa-asterisk',
     title: {
       'bg': 'Сподели в Diaspora',

--- a/src/js/services/facebook.js
+++ b/src/js/services/facebook.js
@@ -32,7 +32,8 @@ module.exports = function(shariff) {
       'zh': '分享'
     },
     name: 'facebook',
-    faName: 'fa-facebook',
+    faPrefix: 'fab',
+    faName: 'fa-facebook-f',
     title: {
       'bg': 'Сподели във Facebook',
       'cs': 'Sdílet na Facebooku',

--- a/src/js/services/flattr.js
+++ b/src/js/services/flattr.js
@@ -9,7 +9,8 @@ module.exports = function(shariff) {
     popup: true,
     shareText: 'Flattr',
     name: 'flattr',
-    faName: 'fa-money',
+    faPrefix: 'far',
+    faName: 'fa-money-bill-alt',
     title: {
       'de': 'Artikel flattrn',
       'en': 'Flattr this'

--- a/src/js/services/googleplus.js
+++ b/src/js/services/googleplus.js
@@ -32,7 +32,8 @@ module.exports = function(shariff) {
       'zh': '分享'
     },
     name: 'googleplus',
-    faName: 'fa-google-plus',
+    faPrefix: 'fab',
+    faName: 'fa-google-plus-g',
     title: {
       'bg': 'Сподели в Google+',
       'cs': 'Sdílet na Google+',

--- a/src/js/services/info.js
+++ b/src/js/services/info.js
@@ -6,6 +6,7 @@ module.exports = function(shariff) {
     popup: shariff.getInfoDisplayPopup(),
     shareText: 'Info',
     name: 'info',
+    faPrefix: 'fas',
     faName: 'fa-info',
     title: {
       'bg': 'Повече информация',

--- a/src/js/services/linkedin.js
+++ b/src/js/services/linkedin.js
@@ -34,7 +34,8 @@ module.exports = function(shariff) {
       'zh': '分享'
     },
     name: 'linkedin',
-    faName: 'fa-linkedin',
+    faPrefix: 'fab',
+    faName: 'fa-linkedin-in',
     title: {
       'bg': 'Сподели в LinkedIn',
       'cs': 'Sdílet na LinkedIn',

--- a/src/js/services/mail.js
+++ b/src/js/services/mail.js
@@ -17,6 +17,7 @@ module.exports = function(shariff) {
       'zh': '分享'
     },
     name: 'mail',
+    faPrefix: 'fas',
     faName: 'fa-envelope',
     title: {
       'bg': 'Изпрати по имейл',

--- a/src/js/services/pinterest.js
+++ b/src/js/services/pinterest.js
@@ -23,6 +23,7 @@ module.exports = function(shariff) {
     popup: true,
     shareText: 'pin it',
     name: 'pinterest',
+    faPrefix: 'fab',
     faName: 'fa-pinterest-p',
     title: {
       'bg': 'Сподели в Pinterest',

--- a/src/js/services/print.js
+++ b/src/js/services/print.js
@@ -6,6 +6,7 @@ module.exports = function(shariff) {
 
   return {
     name: 'print',
+    faPrefix: 'fas',
     faName: 'fa-print',
     popup: false,
     shareText: {

--- a/src/js/services/qzone.js
+++ b/src/js/services/qzone.js
@@ -35,6 +35,7 @@ module.exports = function(shariff) {
       'zh': '分享'
     },
     name: 'qzone',
+    faPrefix: 'fab',
     faName: 'fa-qq',
     title: {
       'bg': 'Сподели в Qzone',

--- a/src/js/services/reddit.js
+++ b/src/js/services/reddit.js
@@ -38,6 +38,7 @@ module.exports = function(shariff) {
       'zh': '分享'
     },
     name: 'reddit',
+    faPrefix: 'fab',
     faName: 'fa-reddit',
     title: {
       'bg': 'Сподели в Reddit',

--- a/src/js/services/stumbleupon.js
+++ b/src/js/services/stumbleupon.js
@@ -38,6 +38,7 @@ module.exports = function(shariff) {
       'zh': '分享'
     },
     name: 'stumbleupon',
+    faPrefix: 'fab',
     faName: 'fa-stumbleupon',
     title: {
       'bg': 'Сподели в Stumbleupon',

--- a/src/js/services/telegram.js
+++ b/src/js/services/telegram.js
@@ -33,6 +33,7 @@ module.exports = function(shariff) {
       'zh': '分享'
     },
     name: 'telegram',
+    faPrefix: 'fab',
     faName: 'fa-telegram',
     title: {
       'bg': 'Сподели в Telegram',

--- a/src/js/services/tencent-weibo.js
+++ b/src/js/services/tencent-weibo.js
@@ -35,6 +35,7 @@ module.exports = function(shariff) {
       'zh': '分享'
     },
     name: 'tencent-weibo',
+    faPrefix: 'fab',
     faName: 'fa-tencent-weibo',
     title: {
       'bg': 'Сподели в tencent weibo',

--- a/src/js/services/threema.js
+++ b/src/js/services/threema.js
@@ -35,6 +35,7 @@ module.exports = function(shariff) {
       'zh': '分享'
     },
     name: 'threema',
+    faPrefix: 'fas',
     faName: 'fa-lock',
     title: {
       'bg': 'Сподели в Threema',

--- a/src/js/services/tumblr.js
+++ b/src/js/services/tumblr.js
@@ -33,6 +33,7 @@ module.exports = function(shariff) {
       'zh': '分享'
     },
     name: 'tumblr',
+    faPrefix: 'fab',
     faName: 'fa-tumblr',
     title: {
       'bg': 'Сподели в tumblr',

--- a/src/js/services/twitter.js
+++ b/src/js/services/twitter.js
@@ -41,6 +41,7 @@ module.exports = function(shariff) {
       'zh': '鸣叫'
     },
     name: 'twitter',
+    faPrefix: 'fab',
     faName: 'fa-twitter',
     title: {
       'bg': 'Сподели в Twitter',

--- a/src/js/services/vk.js
+++ b/src/js/services/vk.js
@@ -32,6 +32,7 @@ module.exports = function(shariff) {
       'zh': '分享'
     },
     name: 'vk',
+    faPrefix: 'fab',
     faName: 'fa-vk',
     title: {
       'bg': 'Сподели във VK',

--- a/src/js/services/weibo.js
+++ b/src/js/services/weibo.js
@@ -35,6 +35,7 @@ module.exports = function(shariff) {
       'zh': '分享'
     },
     name: 'weibo',
+    faPrefix: 'fab',
     faName: 'fa-weibo',
     title: {
       'bg': 'Сподели в weibo',

--- a/src/js/services/whatsapp.js
+++ b/src/js/services/whatsapp.js
@@ -35,6 +35,7 @@ module.exports = function(shariff) {
       'zh': '分享'
     },
     name: 'whatsapp',
+    faPrefix: 'fab',
     faName: 'fa-whatsapp',
     title: {
       'bg': 'Сподели в Whatsapp',

--- a/src/js/services/xing.js
+++ b/src/js/services/xing.js
@@ -32,6 +32,7 @@ module.exports = function(shariff) {
       'zh': '分享'
     },
     name: 'xing',
+    faPrefix: 'fab',
     faName: 'fa-xing',
     title: {
       'bg': 'Сподели в XING',

--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -202,8 +202,8 @@ class Shariff {
         .attr('href', service.shareUrl)
         .append($shareText)
 
-      if (typeof service.faName !== 'undefined') {
-        $shareLink.prepend($('<span/>').addClass(`fa ${service.faName}`))
+      if (typeof service.faPrefix !== 'undefined' && typeof service.faName !== 'undefined') {
+        $shareLink.prepend($('<span/>').addClass(`${service.faPrefix} ${service.faName}`))
       }
 
       if (service.popup) {

--- a/src/style/services/facebook.less
+++ b/src/style/services/facebook.less
@@ -6,7 +6,7 @@
                 background-color: #4273c8;
             }
         }
-        .fa-facebook {
+        .fa-facebook-f {
             font-size: 22px;
         }
         .share_count {
@@ -23,7 +23,7 @@
 
 @media only screen and (min-width: 600px) {
     .shariff {
-        .facebook .fa-facebook {
+        .facebook .fa-facebook-f {
             font-size: 19px;
         }
     }

--- a/src/style/services/flattr.less
+++ b/src/style/services/flattr.less
@@ -10,7 +10,7 @@
                 }
             }
         }
-        .fa-money {
+        .fa-money-bill-alt {
             font-size: 22px;
         }
         .share_count {
@@ -27,7 +27,7 @@
 
 @media only screen and (min-width: 600px) {
     .shariff {
-        .flattr .fa-money {
+        .flattr .fa-money-bill-alt {
             font-size: 19px;
         }
     }

--- a/src/style/services/googleplus.less
+++ b/src/style/services/googleplus.less
@@ -6,7 +6,7 @@
                 background-color: #f75b44;
             }
         }
-        .fa-google-plus {
+        .fa-google-plus-g {
             font-size: 22px;
         }
         .share_count {
@@ -23,7 +23,7 @@
 
 @media only screen and (min-width: 600px) {
     .shariff {
-        .googleplus .fa-google-plus {
+        .googleplus .fa-google-plus-g {
             font-size: 19px;
         }
     }

--- a/src/style/services/linkedin.less
+++ b/src/style/services/linkedin.less
@@ -6,7 +6,7 @@
                 background-color: #0369a0;
             }
         }
-        .fa-linkedin {
+        .fa-linkedin-in {
             font-size: 22px;
         }
         .share_count {
@@ -23,7 +23,7 @@
 
 @media only screen and (min-width: 600px) {
     .shariff {
-        .linkedin .fa-linkedin {
+        .linkedin .fa-linkedin-in {
             font-size: 19px;
         }
     }

--- a/src/style/shariff-complete.less
+++ b/src/style/shariff-complete.less
@@ -1,5 +1,8 @@
 // Font-Awesome
-@import "~font-awesome/less/font-awesome.less";
+@import "~@fortawesome/fontawesome-free-webfonts/less/fontawesome.less";
+@import "~@fortawesome/fontawesome-free-webfonts/less/fa-brands.less";
+@import "~@fortawesome/fontawesome-free-webfonts/less/fa-regular.less";
+@import "~@fortawesome/fontawesome-free-webfonts/less/fa-solid.less";
 
 // Shariff
 @import "shariff-layout";

--- a/src/style/shariff-layout.less
+++ b/src/style/shariff-layout.less
@@ -42,7 +42,9 @@
             vertical-align: middle;
             line-height: 35px;
         }
-        .fa {
+        .fab,
+        .far,
+        .fas {
             width: 35px;
             line-height: 35px;
             text-align: center;
@@ -189,7 +191,9 @@
             a {
                 height: 30px;
             }
-            .fa {
+            .fab,
+            .far,
+            .fas{
                 width: 30px;
                 line-height: 30px;
             }


### PR DESCRIPTION
Font Awesome v4 has reached end of lifetime and so it is time to update to the next version v5.

See [https://github.com/FortAwesome/Font-Awesome/releases/tag/5.0.6](https://github.com/FortAwesome/Font-Awesome/releases/tag/5.0.6).

But they have reorganized their product, and so the less and fonts belong to the npm package [https://www.npmjs.com/package/@fortawesome/fontawesome-free-webfonts](https://www.npmjs.com/package/@fortawesome/fontawesome-free-webfonts) now, of which the current version is `1.0.3`.

In order to be able to add new services like e.g. `FlipBoard`, for which an icon has been added in v5 of Font Awesome, it needs to update Shariff so it uses `@fortawesome/fontawesome-free-webfonts 1.0.3`.

That's what this pull request (PR) does.

Maybe the better way would be to update to the new SVG js way of Font Awesome v5, but this would have a bigger impact on the build procedure of Shariff.

What has changed with the new version is that the icons are distributed into several packages, so there is not always `fa` but `fab` for brands, `fas` for solid and `far` for regular to be added to the class of the `<span>` elements.

Therefore this PR also adds a property `faPrefix` to the js classes of all services and uses that in `shariff.js`.

In addition, some icon names have changed with Font Awesome v5, so the `faName` properties of some services had to be adapted to make the buttons in Shariff still look the same after this PR is applied.

## How to test:

**Requirement:** A Linux host which has npm and git installed.

```sh
$ mkdir shariff-test-prXXX
$ cd shariff-test-prXXX
$ git clone https://github.com/richard67/shariff-plus.git
$ cd shariff-plus
$ git checkout shariff-use-fontawesome-v5
$ git pull origin shariff-use-fontawesome-v5
$ npm install
$ npm run dev
```

Then check the result in the browser, URL=`http://http://localhost:3000/`.

Verify that the icons look the same as in the [standard Shariff demo](http://heiseonline.github.io/shariff/).