### PR TITLE
[Enhancement] Add new option data-button-style to enable small buttons

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -85,6 +85,7 @@ $ npm run dev
 | Attribut         | Beschreibung | Default |
 |------------------|--------------|---------|
 | `data-backend-url` | Pfad zum Shariff-[Backend](#backends). Der Wert `null` deaktiviert die Anzeige von Share-Counts.  | `null` |
+| `data-button-style` | Wie die Buttons angezeigt werden. Werte: `standard`, `icon`, `icon-count`. Bei `icon` wird nur das Icon angezeigt, bei `icon-count` werden Icon und Zähler und bei `standard` Icon, Text und Zähler abhängig von der Display-Größe angezeigt. | `standard` |
 | `data-flattr-category` | Kategorie für Flattr-Spende. | `null` |
 | `data-flattr-user` | Benutzer, der die Flattr-Spende erhält. | `null` |
 | `data-info-url` | URL der Infoseite. | `http://ct.de/-2467514` |

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ $ npm run dev
 | Attribute        | Description | Default |
 |------------------|-------------|---------|
 | `data-backend-url` | The path to your Shariff backend, see below. Setting the value to `null` disables the backend feature. No counts will occur.  | `null` |
+| `data-button-style` | How to display the buttons. Values: `standard`, `icon`, `icon-count`. With `icon` only the icon is shown, with `icon-count` icon and counter and with `standard` icon, text and counter are shown, depending on the display size.  | `standard` |
 | `data-flattr-category` | Category to be used for Flattr. | `null` |
 | `data-flattr-user` | User that receives Flattr donation. | `null` |
 | `data-info-url` | URL of the info page. | `http://ct.de/-2467514` |

--- a/demo/app.less
+++ b/demo/app.less
@@ -24,13 +24,21 @@ article {
             font-weight: bold;
         }
     }
-    &.wide {
+    &.wide, &.wide-icon, &.wide-icon-count {
         h1 {
             font-size: 2em;
             @media only screen and (min-width: 600px) {
                 font-size: 2.9em;
             }
         }
+        #article_content {
+            p {
+                margin: 0;
+                line-height: 1.4;
+            }
+        }
+    }
+    &.wide {
         #article_extras {
             @media only screen and (min-width: 600px) {
                 width: 30%;
@@ -46,10 +54,20 @@ article {
                 width: 70%;
                 float: left;
             }
-            p {
-                margin: 0;
-                line-height: 1.4;
-            }
+        }
+    }
+    &.wide-icon {
+        #article_extras {
+            width: 35px;
+            float: left;
+            padding-right: 30px;
+        }
+    }
+    &.wide-icon-count {
+        #article_extras {
+            width: 80px;
+            float: left;
+            padding-right: 30px;
         }
     }
 }

--- a/demo/app.less
+++ b/demo/app.less
@@ -57,6 +57,7 @@ hr {
     margin: 40px 0 20px;
     border-top: 3px dashed #ccc;
     border-bottom: none;
+    clear: left;
 }
 .layout-hint {
     font-size: .8em;

--- a/demo/index.html
+++ b/demo/index.html
@@ -26,12 +26,43 @@
         <dt>data-backend-url:</dt><dd>/shariff/</dd>
         <dt>data-media-url:</dt><dd>http://www.heise.de/imgs/18/1/4/8/0/5/6/9/wa-encryption-d1999f774c5b5757.png</dd>
         <dt>data-flattr-user:</dt><dd>example</dd>
-        <dt>data-services:</dt><dd>[&amp;quot;addthis&amp;quot;,&amp;quot;whatsapp&amp;quot;,&amp;quot;facebook&amp;quot;,&amp;quot;xing&amp;quot;,&amp;quot;pinterest&amp;quot;,&amp;quot;linkedin&amp;quot;,&amp;quot;tumblr&amp;quot;,&amp;quot;flattr&amp;quot;,&amp;quot;diaspora&amp;quot;,&amp;quot;reddit&amp;quot;,&amp;quot;stumbleupon&amp;quot;,&amp;quot;threema&amp;quot;,&amp;quot;weibo&amp;quot;,&amp;quot;tencent-weibo&amp;quot;,&amp;quot;qzone&amp;quot;,&amp;quot;print&amp;quot;,&amp;quot;telegram&amp;quot;,&amp;quot;vk&amp;quot;,&amp;quot;flipboard&amp;quot;]</dd>
+        <dt>data-services:</dt><dd>[&amp;quot;addthis&amp;quot;,&amp;quot;whatsapp&amp;quot;,&amp;quot;facebook&amp;quot;,&amp;quot;xing&amp;quot;,&amp;quot;pinterest&amp;quot;,&amp;quot;linkedin&amp;quot;,&amp;quot;tumblr&amp;quot;,&amp;quot;flattr&amp;quot;,&amp;quot;diaspora&amp;quot;,&amp;quot;reddit&amp;quot;,&amp;quot;stumbleupon&amp;quot;,&amp;quot;threema&amp;quot;,&amp;quot;weibo&amp;quot;,&amp;quot;tencent-weibo&amp;quot;,&amp;quot;qzone&amp;quot;,&amp;quot;print&amp;quot;,&amp;quot;telegram&amp;quot;,&amp;quot;vk&amp;quot;,&amp;quot;flipboard&amp;quot;,&amp;quot;info&amp;quot;]</dd>
     </dl>
     <article class="slim">
         <header>
             <h1>Lorem ipsum dolor sit amet, consectetuer adipiscing elit</h1>
-            <div data-backend-url="/backend.json" data-flattr-user="example" class="shariff" data-services="[&quot;addthis&quot;,&quot;whatsapp&quot;,&quot;facebook&quot;,&quot;xing&quot;,&quot;pinterest&quot;,&quot;linkedin&quot;,&quot;tumblr&quot;,&quot;flattr&quot;,&quot;diaspora&quot;,&quot;reddit&quot;,&quot;stumbleupon&quot;,&quot;threema&quot;,&quot;weibo&quot;,&quot;tencent-weibo&quot;,&quot;qzone&quot;,&quot;print&quot;,&quot;telegram&quot;,&quot;vk&quot;,&quot;flipboard&quot;]" data-media-url="http://www.heise.de/imgs/18/1/4/8/0/5/6/9/wa-encryption-d1999f774c5b5757.png"></div>
+            <div data-backend-url="/backend.json" data-flattr-user="example" class="shariff" data-services="[&quot;addthis&quot;,&quot;whatsapp&quot;,&quot;facebook&quot;,&quot;xing&quot;,&quot;pinterest&quot;,&quot;linkedin&quot;,&quot;tumblr&quot;,&quot;flattr&quot;,&quot;diaspora&quot;,&quot;reddit&quot;,&quot;stumbleupon&quot;,&quot;threema&quot;,&quot;weibo&quot;,&quot;tencent-weibo&quot;,&quot;qzone&quot;,&quot;print&quot;,&quot;telegram&quot;,&quot;vk&quot;,&quot;flipboard&quot;,&quot;info&quot;]" data-media-url="http://www.heise.de/imgs/18/1/4/8/0/5/6/9/wa-encryption-d1999f774c5b5757.png"></div>
+            <time datetime="2014-11-13T10:45:00+02:00">13.11.2014 - 12:45 Uhr</time>
+        </header>
+        <p class="deck">A small river named Duden flows by their place and supplies it with the necessary regelialia. It is a paradisematic country, in which roasted parts of sentences fly into your mouth.</p>
+    </article>
+    <hr>
+    <dl class="layout-hint">
+        <dt>data-backend-url:</dt><dd>/shariff/</dd>
+        <dt>data-media-url:</dt><dd>http://www.heise.de/imgs/18/1/4/8/0/5/6/9/wa-encryption-d1999f774c5b5757.png</dd>
+        <dt>data-flattr-user:</dt><dd>example</dd>
+        <dt>data-services:</dt><dd>[&amp;quot;addthis&amp;quot;,&amp;quot;whatsapp&amp;quot;,&amp;quot;facebook&amp;quot;,&amp;quot;xing&amp;quot;,&amp;quot;pinterest&amp;quot;,&amp;quot;linkedin&amp;quot;,&amp;quot;tumblr&amp;quot;,&amp;quot;flattr&amp;quot;,&amp;quot;diaspora&amp;quot;,&amp;quot;reddit&amp;quot;,&amp;quot;stumbleupon&amp;quot;,&amp;quot;threema&amp;quot;,&amp;quot;weibo&amp;quot;,&amp;quot;tencent-weibo&amp;quot;,&amp;quot;qzone&amp;quot;,&amp;quot;print&amp;quot;,&amp;quot;telegram&amp;quot;,&amp;quot;vk&amp;quot;,&amp;quot;flipboard&amp;quot;,&amp;quot;info&amp;quot;]</dd>
+        <dt>data-button-style:</dt><dd>icon-count</dd>
+    </dl>
+    <article class="slim">
+        <header>
+            <h1>Lorem ipsum dolor sit amet, consectetuer adipiscing elit</h1>
+            <div data-backend-url="/backend.json" data-flattr-user="example" class="shariff" data-services="[&quot;addthis&quot;,&quot;whatsapp&quot;,&quot;facebook&quot;,&quot;xing&quot;,&quot;pinterest&quot;,&quot;linkedin&quot;,&quot;tumblr&quot;,&quot;flattr&quot;,&quot;diaspora&quot;,&quot;reddit&quot;,&quot;stumbleupon&quot;,&quot;threema&quot;,&quot;weibo&quot;,&quot;tencent-weibo&quot;,&quot;qzone&quot;,&quot;print&quot;,&quot;telegram&quot;,&quot;vk&quot;,&quot;flipboard&quot;,&quot;info&quot;]" data-media-url="http://www.heise.de/imgs/18/1/4/8/0/5/6/9/wa-encryption-d1999f774c5b5757.png" data-button-style="icon-count"></div>
+            <time datetime="2014-11-13T10:45:00+02:00">13.11.2014 - 12:45 Uhr</time>
+        </header>
+        <p class="deck">A small river named Duden flows by their place and supplies it with the necessary regelialia. It is a paradisematic country, in which roasted parts of sentences fly into your mouth.</p>
+    </article>
+    <hr>
+    <dl class="layout-hint">
+        <dt>data-media-url:</dt><dd>http://www.heise.de/imgs/18/1/4/8/0/5/6/9/wa-encryption-d1999f774c5b5757.png</dd>
+        <dt>data-flattr-user:</dt><dd>example</dd>
+        <dt>data-services:</dt><dd>[&amp;quot;addthis&amp;quot;,&amp;quot;whatsapp&amp;quot;,&amp;quot;facebook&amp;quot;,&amp;quot;xing&amp;quot;,&amp;quot;pinterest&amp;quot;,&amp;quot;linkedin&amp;quot;,&amp;quot;tumblr&amp;quot;,&amp;quot;flattr&amp;quot;,&amp;quot;diaspora&amp;quot;,&amp;quot;reddit&amp;quot;,&amp;quot;stumbleupon&amp;quot;,&amp;quot;threema&amp;quot;,&amp;quot;weibo&amp;quot;,&amp;quot;tencent-weibo&amp;quot;,&amp;quot;qzone&amp;quot;,&amp;quot;print&amp;quot;,&amp;quot;telegram&amp;quot;,&amp;quot;vk&amp;quot;,&amp;quot;flipboard&amp;quot;,&amp;quot;info&amp;quot;]</dd>
+        <dt>data-button-style:</dt><dd>icon</dd>
+    </dl>
+    <article class="slim">
+        <header>
+            <h1>Lorem ipsum dolor sit amet, consectetuer adipiscing elit</h1>
+            <div data-flattr-user="example" class="shariff" data-services="[&quot;addthis&quot;,&quot;whatsapp&quot;,&quot;facebook&quot;,&quot;xing&quot;,&quot;pinterest&quot;,&quot;linkedin&quot;,&quot;tumblr&quot;,&quot;flattr&quot;,&quot;diaspora&quot;,&quot;reddit&quot;,&quot;stumbleupon&quot;,&quot;threema&quot;,&quot;weibo&quot;,&quot;tencent-weibo&quot;,&quot;qzone&quot;,&quot;print&quot;,&quot;telegram&quot;,&quot;vk&quot;,&quot;flipboard&quot;,&quot;info&quot;]" data-media-url="http://www.heise.de/imgs/18/1/4/8/0/5/6/9/wa-encryption-d1999f774c5b5757.png" data-button-style="icon"></div>
             <time datetime="2014-11-13T10:45:00+02:00">13.11.2014 - 12:45 Uhr</time>
         </header>
         <p class="deck">A small river named Duden flows by their place and supplies it with the necessary regelialia. It is a paradisematic country, in which roasted parts of sentences fly into your mouth.</p>
@@ -94,6 +125,36 @@
         <h1>Lorem ipsum dolor sit amet, consectetuer adipiscing elit</h1>
         <aside id="article_extras">
             <div data-backend-url="/backend.json?foo=bar" class="shariff" data-orientation="vertical"></div>
+        </aside>
+        <section id="article_content">
+            <p>The Big Oxmox advised her not to do so, because there were thousands of bad Commas, wild Question Marks and devious Semikoli, but the Little Blind Text didn’t listen. She packed her seven versalia, put her initial into the belt and made herself on the way. When she reached the first hills of the Italic Mountains, she had a last view back on the skyline of her hometown Bookmarksgrove, the headline of Alphabet Village and the subline of her own road, the Line Lane. </p>
+        </section>
+    </article>
+    <hr>
+    <dl class="layout-hint">
+        <dt>data-backend-url:</dt><dd>/shariff/?foo=bar</dd>
+        <dt>data-orientation:</dt><dd>vertical</dd>
+        <dt>data-button-style:</dt><dd>icon-count</dd>
+    </dl>
+    <article class="wide-icon-count">
+        <h1>Lorem ipsum dolor sit amet, consectetuer adipiscing elit</h1>
+        <aside id="article_extras">
+            <div data-backend-url="/backend.json?foo=bar" class="shariff" data-orientation="vertical" data-button-style="icon-count"></div>
+        </aside>
+        <section id="article_content">
+            <p>The Big Oxmox advised her not to do so, because there were thousands of bad Commas, wild Question Marks and devious Semikoli, but the Little Blind Text didn’t listen. She packed her seven versalia, put her initial into the belt and made herself on the way. When she reached the first hills of the Italic Mountains, she had a last view back on the skyline of her hometown Bookmarksgrove, the headline of Alphabet Village and the subline of her own road, the Line Lane. </p>
+        </section>
+    </article>
+    <hr>
+    <dl class="layout-hint">
+        <dt>data-backend-url:</dt><dd>/shariff/?foo=bar</dd>
+        <dt>data-orientation:</dt><dd>vertical</dd>
+        <dt>data-button-style:</dt><dd>icon</dd>
+    </dl>
+    <article class="wide-icon">
+        <h1>Lorem ipsum dolor sit amet, consectetuer adipiscing elit</h1>
+        <aside id="article_extras">
+            <div data-backend-url="/backend.json?foo=bar" class="shariff" data-orientation="vertical" data-button-style="icon"></div>
         </aside>
         <section id="article_content">
             <p>The Big Oxmox advised her not to do so, because there were thousands of bad Commas, wild Question Marks and devious Semikoli, but the Little Blind Text didn’t listen. She packed her seven versalia, put her initial into the belt and made herself on the way. When she reached the first hills of the Italic Mountains, she had a last view back on the skyline of her hometown Bookmarksgrove, the headline of Alphabet Village and the subline of her own road, the Line Lane. </p>

--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -41,6 +41,9 @@ const Defaults = {
   // horizontal/vertical
   orientation: 'horizontal',
 
+  // icon/icon-count/standard
+  buttonStyle: 'standard',
+
   // a string to suffix current URL
   referrerTrack: null,
 
@@ -92,7 +95,7 @@ class Shariff {
 
     this._addButtonList()
 
-    if (this.options.backendUrl !== null) {
+    if (this.options.backendUrl !== null && this.options.buttonStyle !== 'icon') {
       this.getShares(this._updateCounts.bind(this))
     }
   }
@@ -188,19 +191,21 @@ class Shariff {
     var $buttonList = $('<ul/>').addClass([
       'theme-' + this.options.theme,
       'orientation-' + this.options.orientation,
+      'button-style-' + this.options.buttonStyle,
       'shariff-col-' + this.options.services.length
     ].join(' '))
 
     // add html for service-links
     this.services.forEach(service => {
       var $li = $('<li/>').addClass(`shariff-button ${service.name}`)
-      var $shareText = $('<span/>')
-        .addClass('share_text')
-        .text(this.getLocalized(service, 'shareText'))
+      var $shareLink = $('<a/>').attr('href', service.shareUrl)
 
-      var $shareLink = $('<a/>')
-        .attr('href', service.shareUrl)
-        .append($shareText)
+      if (this.options.buttonStyle === 'standard') {
+        var $shareText = $('<span/>')
+          .addClass('share_text')
+          .text(this.getLocalized(service, 'shareText'))
+        $shareLink.append($shareText)
+      }
 
       if (typeof service.faPrefix !== 'undefined' && typeof service.faName !== 'undefined') {
         $shareLink.prepend($('<span/>').addClass(`${service.faPrefix} ${service.faName}`))

--- a/src/style/shariff-layout.less
+++ b/src/style/shariff-layout.less
@@ -128,14 +128,26 @@
     // ------------------------- vertical alignment
 
     .orientation-vertical {
-        min-width: 110px;
+        &.button-style-icon {
+            min-width: 35px;
+        }
+        &.button-style-icon-count {
+            min-width: 80px;
+        }
+        &.button-style-standard {
+            min-width: 110px;
+        }
         li {
             display: block;
             width: 100%;
             margin: 5px 0;
-            .share_count {
-                width: 24px;
-                text-align: right;
+        }
+        &.button-style-standard, &.button-style-icon-count {
+            li {
+                .share_count {
+                    width: 24px;
+                    text-align: right;
+                }
             }
         }
     }
@@ -147,17 +159,25 @@
     .shariff .orientation-horizontal {
         li {
             margin-right: 1.8%;
-            min-width: 80px;
-            width: auto;
-            flex: 1 0 auto;
-            .share_count {
-                display: block;
+        }
+        &.button-style-standard, &.button-style-icon-count {
+            li {
+                min-width: 80px;
+                .share_count {
+                    display: block;
+                }
             }
         }
-        &.shariff-col-1, &.shariff-col-2 {
+        &.button-style-standard {
+            li {
+                width: auto;
+                flex: 1 0 auto;
+            }
+        }
+        &.button-style-standard.shariff-col-1, &.button-style-standard.shariff-col-2 {
             .display-share-text;
         }
-        &.shariff-col-5, &.shariff-col-6 {
+        &.button-style-standard.shariff-col-5, &.button-style-standard.shariff-col-6 {
             li {
                 flex: none;
             }
@@ -166,13 +186,13 @@
 }
 
 @media only screen and (min-width: 640px) {
-    .shariff .orientation-horizontal.shariff-col-3 {
+    .shariff .orientation-horizontal.button-style-standard.shariff-col-3 {
         .display-share-text;
     }
 }
 
 @media only screen and (min-width: 768px) {
-    .shariff .orientation-horizontal {
+    .shariff .orientation-horizontal.button-style-standard {
         .display-share-text;
         &.shariff-col-5, &.shariff-col-6 {
             li {


### PR DESCRIPTION
Pull request (PR) for issue #184 

This PR add a new option `data-button-style` to enable small buttons also on large displays.

The option has 3 possible values:

- `standard` is the default for backwards compatibility and is like without this PR.
- `icon` shows always the icons only, i.e. no counters and no share texts. The special sizing of the `info` icon is unchanged.
- `icon-count` shows icons and share counters, i.e. no share text. The share counters disappear with `data-orientation=horizontal` on very small displays in the same way as with the `standard`setting. The buttons have a fixed width of 80px so they all have the same size, regardless if share counters or not. The special sizing of the `info` icon is unchanged. This button style value of course only makes sense if share counters are displayed for some of the buttons.

**Note for maintainers:** The changes are split into several comits, so you can cherry pick the first one if you only want the changes in code and docs but no new examples in the demo.

## How to test:

Depending on your testing environment you can use one of the 2 following methods:

1. Run the shariff demo site locally on a Linux host which has npm installed as described [here in the README.md](https://github.com/heiseonline/shariff#running-demo-site) and check the result with URL=`http://localhost:3000/` in a local browser. This method requires a Linux host which has npm installed.
2. Those who do not have the environment required for method 1 can use modified Shariff packages for the test. Scroll down to Method 2 for the links.

### Method 1

```sh
$ mkdir shariff-test-pr309
$ cd shariff-test-pr309
$ git clone https://github.com/richard67/shariff-plus.git
$ cd shariff-plus
$ git checkout new-option-button-style
$ git pull origin new-option-button-style
$ npm install
$ npm run dev
```
Then check the result in a local web browser, URL=`http://http://localhost:3000/`.

#### Check the result

Check the 3rd and 4th examples with the new option and horizontal Shariff orientation, and the last 2 examples with the new option and vertical Shariff orientation.

Resize your browser window's width to see the behavior for small screens, or use the developer tools of your web browser for that purpose.

### Method 2

Install one of the following packages of `Shariff 2.1.3 plus this PR` on a test website and include some Shariff element on a page, using the different possible values of the new option with horizontal and vertical Shariff orientation:

- [https://test5.richard-fath.de/shariff-2.1.3-test-pr309.tar.gz](https://test5.richard-fath.de/shariff-2.1.3-test-pr309.tar.gz)
- [https://test5.richard-fath.de/shariff-2.1.3-test-pr309.zip](https://test5.richard-fath.de/shariff-2.1.3-test-pr309.zip)

Then open the page with the Shariff elements in a browser.

Finally check the page as described above for method 1 in section "Check the result".