### PR TITLE
added link to the Yellow CMS plugin

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -189,3 +189,4 @@ Bekannte Shariff-Integrationen für Drittanbieter-Systeme:
 * [WordPress-Plugin Shariff Wrapper](https://wordpress.org/plugins/shariff/)
 * [Xenforo [ITM] ctSSB für Xenforo 1.5](https://github.com/McAtze/-ITM-ctShariffSocialButtons)
 * [Xenforo [WMTech] Social Share Privacy Plugin](https://wmtech.net/products/wmtech-social-share-privacy.41/)
+* [Yellow Plugin Shariff](https://github.com/schulle4u/yellow-plugin-shariff)

--- a/README.md
+++ b/README.md
@@ -191,3 +191,4 @@ This is a list of integrations for third-party systems:
 * [WordPress Plugin Shariff Wrapper](https://wordpress.org/plugins/shariff/)
 * [Xenforo [ITM] ctSSB for Xenforo 1.5](https://github.com/McAtze/-ITM-ctShariffSocialButtons)
 * [Xenforo [WMTech] Social Share Privacy Plugin](https://wmtech.net/products/wmtech-social-share-privacy.41/)
+* [Yellow Plugin Shariff](https://github.com/schulle4u/yellow-plugin-shariff)


### PR DESCRIPTION
I've added the link to the Yellow CMS plugin (https://github.com/schulle4u/yellow-plugin-shariff) into the files README.md and README-de.md.
