### PR TITLE
Change link to Java backend

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -166,7 +166,7 @@ Wenn in den Shariff-Buttons die Share-Counts angezeigt werden sollen, wird das f
 
 Drittanbieter-Backends:
 
-* [shariff-backend-java](http://github.com/headissue/shariff-backend-java)
+* [shariff-backend-java](https://github.com/shred/shariff-backend-java)
 
 Die URL, unter der das Backend erreichbar ist, muss im `data`-Attribut `data-backend-url` angegeben werden. Ein Backend unter der URL `http://example.com/my-shariff-backend/` wird in `data-backend-url` so angegeben: `/my-shariff-backend/`. Den Rest erledigt das Skript.
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Shariff supports the following social sharing services:
 - XING
 
 In addition, the service `Info` provides a button to show an info page about the social sharing buttons.
-The URL of this page can be set with an option. Default value: `http://ct.de/-2467514`, i.e. the c't article introducing Shariff. 
+The URL of this page can be set with an option. Default value: `http://ct.de/-2467514`, i.e. the c't article introducing Shariff.
 
 ## Backends
 
@@ -168,7 +168,7 @@ In order to display share counts with Shariff, you need the following backend:
 
 Third-party backends:
 
-* [shariff-backend-java](http://github.com/headissue/shariff-backend-java)
+* [shariff-backend-java](https://github.com/shred/shariff-backend-java)
 
 Once you have one of these backends up and running, insert its URL into the `data-backend-url` attribute. For example, if the backend runs under `http://example.com/my-shariff-backend/`, the `data-backend-url` should be `/my-shariff-backend/`. The script will handle the rest.
 


### PR DESCRIPTION
The previous `shariff-backend-java` seems to be unmaintained. The last commit was in Feb 2015. I took the freedom to change the link to my own `shariff-backend-java`, which is a different implementation, but still active.