### PR TITLE
Handle protocol agnostic URI with domain in canonical link

### DIFF
--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -65,7 +65,11 @@ const Defaults = {
 
     if (canonical.length > 0) {
       if (canonical.indexOf('http') < 0) {
-        canonical = global.document.location.protocol + '//' + global.document.location.host + canonical
+        if (canonical.indexOf('//') !== 0) {
+          canonical = global.document.location.protocol + '//' + global.document.location.host + canonical
+        } else {
+          canonical = global.document.location.protocol + canonical
+        }
       }
       url = canonical
     }


### PR DESCRIPTION
Currently Shariff expands canonical URI read from `og:url` or canonical link tag with protocol and domain, if it doesn't find a leading "http" in the URI. 

Example on domain _test.com_:
"`/index.html`" expands to "`http://test.com/index.html`"

This behavior produces invalid results if the URI has to leading slashes (a protocol agnostic URI with domain) as it expands "`//test.com/index.html`" on domain _test.com_ to "`http://test.com//test.com/index.html`"

The pull request fixes this, as there only the protocol will be added in such cases.
