### PR TITLE
Update Xing sharing link URL

### DIFF
--- a/src/js/services/xing.js
+++ b/src/js/services/xing.js
@@ -61,6 +61,6 @@ module.exports = function(shariff) {
       'tr': 'XING\'ta paylaş',
       'zh': '分享至XING'
     },
-    shareUrl: 'https://www.xing.com/social_plugins/share?url=' + url + shariff.getReferrerTrack()
+    shareUrl: 'https://www.xing.com/spi/shares/new?url=' + url + shariff.getReferrerTrack()
   }
 }


### PR DESCRIPTION
Pull request (PR) for issue #353 .

It seems that either Xing have changed their sharing URL, or the link in Shariff was always different to what is written in Xing documentation on [https://dev.xing.com/plugins/share_button/docs](https://dev.xing.com/plugins/share_button/docs), section "Custom design":

> We recommend using the generator to create your Share Button. However, you can use your own custom button with the following link:
> 
> https://www.xing.com/spi/shares/new?url=[URL_TO_BE_SHARED]

My favourite source for sharing links [https://github.com/vinkla/shareable-links/blob/master/README.md#xing](https://github.com/vinkla/shareable-links/blob/master/README.md#xing) also uses `https://www.xing.com/spi/shares/new?url=`.

For some reason the `https://www.xing.com/social_plugins/share?url=` currently used by Shariff also works for me, but not for the author of issue #353 .

Of course I've tested the changes of this PR.

## How to test:

Run the shariff demo site locally on a Linux host which has git and npm installed with the branch of this PR as follows:

```sh
$ mkdir shariff-test-pr354
$ cd shariff-test-pr354
$ git clone https://github.com/richard67/shariff-plus.git
$ cd shariff-plus
$ git checkout patch-1
$ git pull origin patch-1
$ npm install
$ npm run dev
```
Check the result in the browser, URL=`http://localhost:3000/`.

#### Check the result

Verify that the Xing sharing links in examples 2 to 4 of the demo still work (or work again if it has not worked before).

#### Clean up after the test
```sh
$ cd ../..
$ rm -rf ./shariff-test-pr354
```
