### PR TITLE
Update fontawesome to version 5.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@fortawesome/fontawesome-free-webfonts": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free-webfonts/-/fontawesome-free-webfonts-1.0.9.tgz",
-      "integrity": "sha512-nLgl6b6a+tXaoJJnSRw0hjN8cWM/Q5DhxKAwI9Xr0AiC43lQ2F98vQ1KLA6kw5OoYeAyisGGqmlwtBj0WqOI5Q=="
+    "@fortawesome/fontawesome-free": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.8.1.tgz",
+      "integrity": "sha512-GJtx6e55qLEOy2gPOsok2lohjpdWNGrYGtQx0FFT/++K4SYx+Z8LlPHdQBaFzKEwH5IbBB4fNgb//uyZjgYXoA=="
     },
     "accepts": {
       "version": "1.3.5",
@@ -4255,12 +4255,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4275,17 +4277,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4402,7 +4407,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4414,6 +4420,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4428,6 +4435,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4435,12 +4443,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4459,6 +4469,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4539,7 +4550,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4551,6 +4563,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4672,6 +4685,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4255,14 +4255,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4277,20 +4275,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4407,8 +4402,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4420,7 +4414,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4435,7 +4428,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4443,14 +4435,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4469,7 +4459,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4550,8 +4539,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4563,7 +4551,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4685,7 +4672,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     }
   ],
   "dependencies": {
-    "@fortawesome/fontawesome-free-webfonts": "^1.0.9",
+    "@fortawesome/fontawesome-free": "^5.8.1",
     "jquery": "^3.3.1"
   },
   "publishConfig": {

--- a/src/style/shariff-complete.less
+++ b/src/style/shariff-complete.less
@@ -1,8 +1,8 @@
 // Font-Awesome
-@import "~@fortawesome/fontawesome-free-webfonts/less/fontawesome.less";
-@import "~@fortawesome/fontawesome-free-webfonts/less/fa-brands.less";
-@import "~@fortawesome/fontawesome-free-webfonts/less/fa-regular.less";
-@import "~@fortawesome/fontawesome-free-webfonts/less/fa-solid.less";
+@import "~@fortawesome/fontawesome-free/less/fontawesome.less";
+@import "~@fortawesome/fontawesome-free/less/brands.less";
+@import "~@fortawesome/fontawesome-free/less/regular.less";
+@import "~@fortawesome/fontawesome-free/less/solid.less";
 
 // Shariff
 @import "shariff-layout";


### PR DESCRIPTION
This pull request (PR) updates fontawesome free webfonts to the latest version 5.8.1.

It is a requirement for being able to add new services like e.g. [buffer](https://buffer.com/), for which new brand icons have been added recently to fontawesome free.

Since the last update of fontawesome with PR #302 , the structure of the fontawesome npm repository has changed again, so the separate repository for the webfonts has been deprecated, see here: [https://www.npmjs.com/package/@fortawesome/fontawesome-free-webfonts](https://www.npmjs.com/package/@fortawesome/fontawesome-free-webfonts).

Instead of this, the repository [https://www.npmjs.com/package/@fortawesome/fontawesome-free](https://www.npmjs.com/package/@fortawesome/fontawesome-free) shall be used.

See upgrading information here: [https://github.com/FortAwesome/Font-Awesome/blob/master/UPGRADING.md#50x-to-510](https://github.com/FortAwesome/Font-Awesome/blob/master/UPGRADING.md#50x-to-510).

## How to test:

Run the shariff demo site locally on a Linux host which has git and npm installed with the branch of this PR as follows:

```sh
$ mkdir shariff-test-pr360
$ cd shariff-test-pr360
$ git clone https://github.com/richard67/shariff-plus.git
$ cd shariff-plus
$ git checkout upstream-update-fontawesome-510
$ git pull origin upstream-update-fontawesome-510
$ npm install
$ npm run build
$ npm run dev
```
#### Check the result

1. Check the result in the browser, URL=`http://localhost:3000/`: Verify that the buttons are shown with the right icons.
2. Download fontawesome free 5.8.1 from [here](https://github.com/FortAwesome/Font-Awesome/releases/tag/5.8.1), unpack to some temporary folder and verify that the web fonts files in sub-folder `webfonts` of that temporary folder are identical with the fonts files in sub-folder `dist` of the git repository (`shariff-test-pr360/shariff-plus`).

#### Clean up after the test
```sh
$ cd ../..
$ rm -rf ./shariff-test-pr360
```
