### PR TITLE
Remove LinkedIn share count from backend.json

### DIFF
--- a/demo/backend.json
+++ b/demo/backend.json
@@ -1,1 +1,1 @@
-{"buffer":123,"facebook":906,"linkedin":92,"reddit":12,"stumbleupon":4325,"vk":57,"xing":185}
+{"buffer":123,"facebook":906,"reddit":12,"stumbleupon":4325,"vk":57,"xing":185}


### PR DESCRIPTION
In February 2018, LinkedIn announced that their Share button will not show any counts anymore, and the API to fetch counts from also has been closed.

See announcement here: [https://developer.linkedin.com/blog/posts/2018/deprecating-the-inshare-counter](https://developer.linkedin.com/blog/posts/2018/deprecating-the-inshare-counter) .

This pull request (PR) removes the share count for LinkedIn from the dummy backend "backend.json" used for the demo.

PR for removing LinkedIn from the PHP backend: [https://github.com/heiseonline/shariff-backend-php/pull/159](https://github.com/heiseonline/shariff-backend-php/pull/159)

This PR here should be merged soon after the PR for the PHP backend has been merged and a new backend release has been made.