### PR TITLE
Update Whatsapp provider to use newer sharing URL that works on mobile devices and desktop browsers

### DIFF
--- a/src/js/services/whatsapp.js
+++ b/src/js/services/whatsapp.js
@@ -64,6 +64,6 @@ module.exports = function(shariff) {
       'tr': 'Whatsapp\'ta paylaş',
       'zh': '在Whatsapp上分享'
     },
-    shareUrl: 'whatsapp://send?text=' + encodeURIComponent(title) + '%20' + url + shariff.getReferrerTrack()
+    shareUrl: 'https://wa.me/?text=' + encodeURIComponent(title) + '%20' + url + shariff.getReferrerTrack()
   }
 }


### PR DESCRIPTION
See https://faq.whatsapp.com/en/general/26000030/?category=5245251:

> To create a link with just a pre-filled message, use https://wa.me/?text=urlencodedtext
> 
> Example:https://wa.me/?text=I'm%20inquiring%20about%20the%20apartment%20listing

Using the https://wa.me URL means that the sharing link will work on mobile devices _and_ in a desktop web browser.

I think this would fix #352.