### PR TITLE
WhatsApp: Support for WhatsApp Web by updating url

### DIFF
--- a/src/js/services/whatsapp.js
+++ b/src/js/services/whatsapp.js
@@ -64,6 +64,6 @@ module.exports = function(shariff) {
       'tr': 'Whatsapp\'ta paylaş',
       'zh': '在Whatsapp上分享'
     },
-    shareUrl: 'whatsapp://send?text=' + encodeURIComponent(title) + '%20' + url + shariff.getReferrerTrack()
+    shareUrl: 'https://api.whatsapp.com/send?text=' + encodeURIComponent(title) + '%20' + url + shariff.getReferrerTrack()
   }
 }


### PR DESCRIPTION
**Short: Make the WhatsApp-Links compatible with WhatsApp Web**

By using [`https://api.whatsapp.com/send?text=A Text`](https://api.whatsapp.com/send?text=A%20Text) instead of [`whatsapp://send?text=A Text`](whatsapp://send?text=A%20Text)

> Pull Request #366 makes the same, but using [`wa.me`](https://wa.me/) which is just a redirect to [`api.whatsapp.com`](https://api.whatsapp.com/). So for the performance, this pull request with this link is better.

> This pull request will fix #352

## Overview Links

##### Mobile Only
- `whatsapp://send?text=A Text`

##### Web and Mobile
- [`https://wa.me/send?text=A Text`](https://wa.me/send?text=A&20Text) _(Redirect to api.whatsapp.com)_
- [`https://api.whatsapp.com/send?text=A Text`](https://api.whatsapp.com/send?text=A%20Text)

<!--
Please check:

- [x] Your pull request has a meaningful title.
- [x] The description explains the changes proposed by the pull request and why you believe they are necessary.
- [x] Relevant issues and pull requests are mentioned.
- [x] The pull request contains documentation in README.md/README-de.md if necessary.
- [x] You did not include any build artifacts.
-->
