### PR TITLE
LinkedIn Sharer-URL to 2020 Version

### DIFF
--- a/src/js/services/linkedin.js
+++ b/src/js/services/linkedin.js
@@ -2,8 +2,6 @@
 
 module.exports = function(shariff) {
   var url = encodeURIComponent(shariff.getURL())
-  var title = encodeURIComponent(shariff.getTitle())
-  var descr = encodeURIComponent(shariff.getMeta('description'))
   return {
     popup: true,
     shareText: {
@@ -63,6 +61,6 @@ module.exports = function(shariff) {
       'tr': 'LinkedIn\'ta paylaş',
       'zh': '在LinkedIn上分享'
     },
-    shareUrl: 'https://www.linkedin.com/shareArticle?mini=true&summary=' + descr + '&title=' + title + '&url=' + url
+    shareUrl: 'https://www.linkedin.com/sharing/share-offsite/?url=' + url
   }
 }


### PR DESCRIPTION
**Updates the Sharer-URL to 2020 Version.**

Currently: [`https://www.linkedin.com/shareArticle?url={url}&title={title}&summary={text}&source={provider}`](https://www.linkedin.com/shareArticle?url=example.com&title=Example&summary=Example%20Summary&source=GitHub%20Issue)
2020 Version _(This PR)_: [`https://www.linkedin.com/sharing/share-offsite/?url={url}`](https://www.linkedin.com/sharing/share-offsite/?url=example.com)

> This pull request will fix #378.

[More information](https://github.com/bradvin/social-share-urls#linkedin)

<!--
Please check:

- [x] Your pull request has a meaningful title.
- [x] The description explains the changes proposed by the pull request and why you believe they are necessary.
- [x] Relevant issues and pull requests are mentioned.
- [x] The pull request contains documentation in README.md/README-de.md if necessary.
- [x] You did not include any build artifacts.
-->
