### PR TITLE
Twitter: Updated max text length

### DIFF
--- a/src/js/services/twitter.js
+++ b/src/js/services/twitter.js
@@ -30,7 +30,7 @@ module.exports = function(shariff) {
   // From Twitters documentation (May 2021):
   // The length of your passed Tweet text should not exceed 280 characters
   // when combined with any passed hashtags, via, or url parameters.
-  var remainingTextLength = (280 - shareUrl.query.via.length - shareUrl.query.url.length)
+  var remainingTextLength = (280 - (shareUrl.query.via || '').length - (shareUrl.query.url || '').length)
   shareUrl.query.text = abbreviateText(title, remainingTextLength)
 
   delete shareUrl.search

--- a/src/js/services/twitter.js
+++ b/src/js/services/twitter.js
@@ -30,7 +30,7 @@ module.exports = function(shariff) {
   // From Twitters documentation (May 2021):
   // The length of your passed Tweet text should not exceed 280 characters
   // when combined with any passed hashtags, via, or url parameters.
-  var remainingTextLength = 280 - shareUrl.query.via.length - shareUrl.query.url.length;
+  var remainingTextLength = (280 - shareUrl.query.via.length - shareUrl.query.url.length)
   shareUrl.query.text = abbreviateText(title, remainingTextLength)
 
   delete shareUrl.search

--- a/src/js/services/twitter.js
+++ b/src/js/services/twitter.js
@@ -23,12 +23,16 @@ module.exports = function(shariff) {
 
   var title = shariff.getTitle()
 
-  // 120 is the max character count left after twitters automatic url shortening with t.co
-  shareUrl.query.text = abbreviateText(title, 120)
   shareUrl.query.url = shariff.getURL()
   if (shariff.options.twitterVia !== null) {
     shareUrl.query.via = shariff.options.twitterVia
   }
+  // From Twitters documentation (May 2021):
+  // The length of your passed Tweet text should not exceed 280 characters
+  // when combined with any passed hashtags, via, or url parameters.
+  var remainingTextLength = 280 - shareUrl.query.via.length - shareUrl.query.url.length;
+  shareUrl.query.text = abbreviateText(title, remainingTextLength)
+
   delete shareUrl.search
 
   return {


### PR DESCRIPTION
This pull request updates the max length of tweet texts which has been doubled from 140 to 280 in 2017 and thus fixes the text of tweets being trimmed more than necessary.
