### PR TITLE
Update linkedin share due to linkedin updating the share api

### DIFF
--- a/src/js/services/linkedin.js
+++ b/src/js/services/linkedin.js
@@ -63,6 +63,6 @@ module.exports = function(shariff) {
       'tr': 'LinkedIn\'ta paylaş',
       'zh': '在LinkedIn上分享'
     },
-    shareUrl: 'https://www.linkedin.com/shareArticle?mini=true&summary=' + descr + '&title=' + title + '&url=' + url
+    shareUrl: 'https://www.linkedin.com/sharing/share-offsite/?url= '+ url
   }
 }


### PR DESCRIPTION
LinkedIn updated its Sharing-API to use OG data from the supplied url. 
It need a new sharing URL and then only the URL of the website that should be shared -> https://www.linkedin.com/sharing/share-offsite/?url={url}

References:
* https://www.linkedin.com/help/linkedin/answer/a521928/make-your-website-shareable-on-linkedin
* https://stackoverflow.com/questions/33426752/linkedin-share-post-url