### PR TITLE
Fix tests failing due to PhantomJS not starting

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/js/shariff.js",
   "scripts": {
     "dev": "webpack-dev-server --hot --inline --port 3000 --content-base demo --entry app=./demo/app.js",
-    "test": "eslint src && karma start --single-run",
+    "test": "eslint src && export OPENSSL_CONF=/dev/null && karma start --single-run",
     "build": "rm -fr dist && webpack -p",
     "build_zip": "7z a -tzip $BASE_NAME.zip ./dist/* && 7z a -ttar $BASE_NAME.tar ./dist/* && 7z a $BASE_NAME.tar.gz $BASE_NAME.tar",
     "prepare": "husky install"


### PR DESCRIPTION
This pull request (PR) fixes the tests not working because the PhantomJS browser could not be started.

For details on the fix see https://stackoverflow.com/questions/73004195/phantomjs-wont-install-autoconfiguration-error .

### Testing instructions

Fetch the current development branch of this repo into a git clone on Ubuntu 22.04 or newer or similar current Linux distributions.

Run `npm install`.

Run `npm run test`.

Result:
```
...
04 01 2025 12:48:57.618:ERROR [launcher]: PhantomJS failed 2 times (cannot start). Giving up.

Finished in 0 secs / 0 secs @ 12:48:57 GMT+0100 (Mitteleuropäische Normalzeit)
```

Apply the change from this PR.

Run `npm run test`.

Result:
```
...
Finished in 0.048 secs / 0.008 secs @ 12:54:49 GMT+0100 (Mitteleuropäische Normalzeit)

SUMMARY:
✔ 21 tests completed
```